### PR TITLE
Remove Guava dependency from SDK module.

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -106,9 +106,9 @@ uploadArchives {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.google.guava:guava:18.0'
     compile 'com.google.http-client:google-http-client-jackson2:1.19.0'
 
+    testCompile 'com.google.guava:guava:18.0'
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:1.9.5"
     testCompile "org.robolectric:robolectric:3.0"

--- a/sdk/src/main/java/com/uber/sdk/android/rides/RequestDeeplink.java
+++ b/sdk/src/main/java/com/uber/sdk/android/rides/RequestDeeplink.java
@@ -31,7 +31,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
-import com.google.common.base.Preconditions;
+import com.uber.sdk.android.rides.utils.Preconditions;
 
 
 /**

--- a/sdk/src/main/java/com/uber/sdk/android/rides/utils/Preconditions.java
+++ b/sdk/src/main/java/com/uber/sdk/android/rides/utils/Preconditions.java
@@ -1,0 +1,38 @@
+package com.uber.sdk.android.rides.utils;
+
+import android.support.annotation.Nullable;
+
+/**
+ * Methods that help to check whether method or constructor invoked properly.
+ * <p/>
+ * Created by Antonenko Viacheslav on 24/02/16.
+ */
+public final class Preconditions {
+
+    private Preconditions() {
+        throw new AssertionError();
+    }
+
+
+    /**
+     * @param expression a boolean expression
+     * @throws IllegalStateException if {@code expression} is false
+     */
+    public static void checkState(boolean expression) {
+        if (!expression) {
+            throw new IllegalStateException();
+        }
+    }
+
+    /**
+     * @param expression   a boolean expression
+     * @param errorMessage the exception message to use if the check fails; will be converted to a
+     *                     string using {@link String#valueOf(Object)}
+     * @throws IllegalStateException if {@code expression} is false
+     */
+    public static void checkState(boolean expression, @Nullable Object errorMessage) {
+        if (!expression) {
+            throw new IllegalStateException(String.valueOf(errorMessage));
+        }
+    }
+}


### PR DESCRIPTION
Guava library contains 14833 methods, but SDK uses only one method Preconditions.checkState. So I remove Guava library and add own Preconditions implementations.