### PR TITLE
Remove Google HTTP Client from SDK dependencies.

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -107,7 +107,6 @@ uploadArchives {
 dependencies {
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.google.guava:guava:18.0'
-    compile 'com.google.http-client:google-http-client-jackson2:1.19.0'
 
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:1.9.5"

--- a/sdk/src/test/java/com/uber/sdk/android/rides/TestUtils.java
+++ b/sdk/src/test/java/com/uber/sdk/android/rides/TestUtils.java
@@ -24,7 +24,7 @@ package com.uber.sdk.android.rides;
 
 import android.support.annotation.NonNull;
 
-import com.google.api.client.repackaged.com.google.common.base.Joiner;
+import com.google.common.base.Joiner;
 import com.google.common.io.Files;
 
 import java.io.File;


### PR DESCRIPTION
We can call Joiner from Guava library instead of Google HTTP Client. Also it will decrease SDK method count.