### PR TITLE
Customize RequestRidesButton Text Size

### DIFF
--- a/rides-android/src/main/java/com/uber/sdk/android/rides/RideRequestButton.java
+++ b/rides-android/src/main/java/com/uber/sdk/android/rides/RideRequestButton.java
@@ -225,23 +225,38 @@ public class RideRequestButton extends FrameLayout implements RideRequestButtonV
                 attrsResources,
                 defStyleAttr,
                 defStyleRes);
+
+        TypedArray textSizeAttributes = context.getTheme().obtainStyledAttributes(
+                attrs,
+                R.styleable.RideRequestButton,
+                defStyleAttr,
+                defStyleRes);
+        int primaryTextSize = (int) textSizeAttributes.getDimension(
+                R.styleable.RideRequestButton_ub__primary_text_size,
+                getResources().getDimension(R.dimen.ub__text_size));
+        int secondaryTextSize = (int) textSizeAttributes.getDimension(
+                R.styleable.RideRequestButton_ub__secondary_text_size,
+                getResources().getDimension(R.dimen.ub__secondary_text_size));
+        textSizeAttributes.recycle();
+
         try {
-            applyTextAttributes(priceEstimateView, textAttributes);
-            applyTextAttributes(timeEstimateView, textAttributes);
-            applyTextAttributes(requestButton, textAttributes);
+            applyTextAttributes(priceEstimateView, textAttributes, secondaryTextSize);
+            applyTextAttributes(timeEstimateView, textAttributes, secondaryTextSize);
+            applyTextAttributes(requestButton, textAttributes, primaryTextSize);
         } finally {
             textAttributes.recycle();
         }
     }
 
     @SuppressLint("ResourceType")
-    private void applyTextAttributes(TextView textView, TypedArray textAttributes) {
+    private void applyTextAttributes(TextView textView, TypedArray textAttributes, int textSize) {
         textView.setTextColor(textAttributes.getColor(0, Color.WHITE));
         textView.setTypeface(Typeface.defaultFromStyle(textAttributes.getInt(3, Typeface.NORMAL)));
         String text = textAttributes.getString(4);
         if (text != null) {
             textView.setText(textAttributes.getString(4));
         }
+        textView.setTextSize(textSize);
     }
 
     @SuppressLint("ResourceType")

--- a/rides-android/src/main/res/values/attrs.xml
+++ b/rides-android/src/main/res/values/attrs.xml
@@ -25,5 +25,7 @@
 
     <declare-styleable name="RideRequestButton">
         <attr name="ub__style" />
+        <attr name="ub__primary_text_size" format="dimension" />
+        <attr name="ub__secondary_text_size" format="dimension" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
I add primary and secondary text size attributes in RideRequestButton to be able to customize font size.
This gives developers certain flexibility to support small, normal and large screens

Please see this related issue:
https://github.com/uber/rides-android-sdk/issues/34
