### PR TITLE
Do not return auth error in case of fallback to auth code grant

### DIFF
--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginManager.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginManager.java
@@ -314,6 +314,7 @@ public class LoginManager {
         } else if (authenticationError.equals(AuthenticationError.UNAVAILABLE)
                 && redirectForAuthorizationCode) {
             loginForAuthorizationCode(activity);
+            return;
         } else if (AuthenticationError.INVALID_APP_SIGNATURE.equals(authenticationError)) {
             AppProtocol appProtocol = new AppProtocol();
             String appSignature = appProtocol.getAppSignature(activity);

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginManagerTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginManagerTest.java
@@ -62,6 +62,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -278,6 +279,8 @@ public class LoginManagerTest extends RobolectricTestBase {
         loginManager.setRedirectForAuthorizationCode(true);
         loginManager.onActivityResult(activity, REQUEST_CODE_LOGIN_DEFAULT, Activity.RESULT_CANCELED, intent);
 
+        verify(callback, never()).onLoginError(AuthenticationError.UNAVAILABLE);
+
         ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
 
         verify(activity).startActivityForResult(intentCaptor.capture(), eq(REQUEST_CODE_LOGIN_DEFAULT));
@@ -312,6 +315,8 @@ public class LoginManagerTest extends RobolectricTestBase {
         Intent intent = new Intent().putExtra(EXTRA_ERROR, AuthenticationError.UNAVAILABLE.toStandardString());
 
         loginManager.onActivityResult(activity, REQUEST_CODE_LOGIN_DEFAULT, Activity.RESULT_CANCELED, intent);
+
+        verify(callback, never()).onLoginError(AuthenticationError.UNAVAILABLE);
 
         ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
 


### PR DESCRIPTION
In case of `LoginManager#onActivityResult()` with an `AuthenticationError.UNAVAILABLE` and `redirectForAuthorizationCode == true`, `LoginManager` automatically falls back to the authorization code grant flow.

However, it *also* incorrectly calls `LoginCallback#onLoginError` with `AuthenticationError.UNAVAILABLE`.