### PR TITLE
Retrieve auth code by intercepting URL loading

### DIFF
--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginActivity.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginActivity.java
@@ -235,12 +235,13 @@ public class LoginActivity extends Activity {
             super(redirectUri);
         }
 
-
         @Override
-        public void onPageFinished(WebView view, String url) {
-            if (url.startsWith(redirectUri)) {
+        public boolean shouldOverrideUrlLoading(WebView view, String url) {
+            if(url.startsWith(redirectUri)) {
                 onCodeReceived(Uri.parse(url));
+                return true;
             }
+            return super.shouldOverrideUrlLoading(view, url);
         }
     }
 

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/OAuthWebViewClientTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/OAuthWebViewClientTest.java
@@ -174,12 +174,12 @@ public class OAuthWebViewClientTest extends RobolectricTestBase {
     }
 
     @Test
-    public void onPageFinished_withMatchingRedirectUri_shouldReturnedUri() {
+    public void shouldOverrideUrlLoading_withMatchingRedirectUri_shouldReturnUri() {
         client = testLoginActivity.new AuthorizationCodeClient(REDIRECT_URI);
 
         String redirectUrl = REDIRECT_URI + "code=myCode123";
 
-        client.onPageFinished(mock(WebView.class), redirectUrl);
+        client.shouldOverrideUrlLoading(mock(WebView.class), redirectUrl);
 
         verify(testLoginActivity).onCodeReceived(eq(Uri.parse(redirectUrl)));
     }


### PR DESCRIPTION
#### Issue
The authorization code grant flow via `LoginActivity` does not work on a Samsung Galaxy S7 with Android 7.0 for certain redirect URLs (did not test on other devices, but presumably it is broken elsewhere, too).

#### Expected
After a successful login, receive a callback to `LoginCallback#onAuthorizationCodeReceived`.

#### Actual
After a successful login, receive a callback to `LoginCallback#onLoginError`.

#### Explanation

When trying to complete the authorization code grant flow, both `OAuthWebViewClient#onReceivedError` and `AuthorizationCodeClient#onPageFinished` are called, in that order.

`OAuthWebViewClient` receives `onReceivedError` with the following `WebResourceError`s for the respective redirect URIs:
- `myapp://uberauth?code={my_auth_code}` -> `net::ERR_UNKNOWN_URL_SCHEME`
- `https://localhost?code={my_auth_code}` -> `net::ERR_CONNECTION_REFUSED`

Despite `AuthorizationCodeClient#onPageFinished` being called later, `LoginActivity` exits with a canceled result and `AuthenticationError.CONNECTIVITY_ISSUE`, resulting in a callback to `LoginCallback#onLoginError` instead of the expected `LoginCallback#onAuthorizationCodeReceived`.

#### Solution
Intercept the URL in `WebViewClient#shouldOverrideUrlLoading` instead of `WebViewClient#onPageFinished`. This does not attempt to load the redirect URL and `OAuthWebViewClient#onReceivedError` is not called.

This furthermore makes `AuthorizationCodeClient` consistent with `AccessTokenClient`, which already uses the `shouldOverrideUrlLoading` approach.

This solution presumes the intended behavior is to return the authorization code via `LoginCallback#onAuthorizationCodeReceived` and leave any further behavior up to the client. If the intended behavior is to both hit the redirect URL *and* call `LoginCallback#onAuthorizationCodeReceived`, a different solution is necessary.