### PR TITLE
Fix Release script based on .7 release feedback.

### DIFF
--- a/gradle/github-release.gradle
+++ b/gradle/github-release.gradle
@@ -20,12 +20,7 @@ def checkAndDefaultProperty(prop) {
 
 def checkProperty(prop) {
     if (!project.hasProperty(prop)) {
-        def message = "Add " + prop + " to your ~/.gradle/gradle.properties file."
-        if (isReleaseBuild()) {
-            throw new GradleException(message)
-        } else {
-            logger.warn(message)
-        }
+        logger.warn("Add " + prop + " to your ~/.gradle/gradle.properties file.")
     }
 }
 

--- a/gradle/github-release.gradle
+++ b/gradle/github-release.gradle
@@ -35,14 +35,14 @@ def isReleaseBuild() {
 
 def generateReleaseNotes() {
     def changelogSnippet = generateChangelogSnippet()
-    def model = [title  : "Uber Rides Android SDK (Beta) v${findProperty("version")}",
+    def model = [title  : "Uber Rides Android SDK (Beta) v${rootProject.version}",
                  date   : DateGroovyMethods.format(new Date(), 'MM/dd/yyyy'),
                  snippet: changelogSnippet,
                  assets : project.samples.collect {
                      [
                              title      : project(it).name,
-                             download   : GITHUB_DOWNLOAD_PREFIX + "v${findProperty("version")}/"
-                                     + project(it).name + "-v${findProperty("version")}.zip",
+                             download   : GITHUB_DOWNLOAD_PREFIX + "v${rootProject.version}/"
+                                     + project(it).name + "-v${rootProject.version}.zip",
                              description: project(it).description,
                      ]
                  }]
@@ -66,8 +66,12 @@ def generateChangelogSnippet() {
     return "  " + snippet.trim()
 }
 
+task test2 << {
+    rootProject.version="0.9.0-SNAPSHOT"
+}
+
 task updateReleaseVersionChangelog() << {
-    def newVersion = findProperty("version").replaceAll('-SNAPSHOT', '')
+    def newVersion = rootProject.version.replaceAll('-SNAPSHOT', '')
     def changelog = rootProject.file('CHANGELOG.md')
     def changelogText = changelog.text
     def date = new Date().format('MM/dd/yyyy')
@@ -81,7 +85,7 @@ task updateReleaseVersionChangelog() << {
 }
 
 task updateNewVersionChangelog() << {
-    def newVersion = findProperty("version").replaceAll('-SNAPSHOT', '')
+    def newVersion = rootProject.version.replaceAll('-SNAPSHOT', '')
     def changelog = rootProject.file('CHANGELOG.md')
     def changelogText = changelog.text
 
@@ -112,30 +116,30 @@ github {
     owner = GITHUB_OWNER
     repo = GITHUB_REPO
     token = "${GITHUB_TOKEN}"
-    tagName = "v${findProperty("version")}"
+    tagName = "v${rootProject.version}"
     targetCommitish = GITHUB_BRANCH
-    name = "v${findProperty("version")}"
+    name = "v${rootProject.version}"
     body = generateReleaseNotes()
     assets = project.samples.collect {
         project(it).buildDir.absolutePath + "/distributions/" + project(it).name +
-                "-v${findProperty("version")}.zip"
+                "-v${rootProject.version}.zip"
     }
 }
 
 subprojects {
     configure(subprojects.findAll {it.parent.name == 'samples'}) {
         task githubReleaseZip(type: Zip) << {
-            version = "v${findProperty("version")}"
+            version = "v${rootProject.version}"
 
             from('.') {
                 filesNotMatching("**/*.png") {
                     filter { String line ->
                         line.replaceAll("compile project\\(':rides-android'\\)",
-                                "compile '${groupId}:rides-android:${findProperty("version")}'")
+                                "compile '${groupId}:rides-android:${rootProject.version}'")
                     }
                     filter { String line ->
                         line.replaceAll("compile project\\(':core-android'\\)",
-                                "compile '${groupId}:core-android:${findProperty("version")}'")
+                                "compile '${groupId}:core-android:${rootProject.version}'")
                     }
                 }
                 into '.'

--- a/gradle/github-release.gradle
+++ b/gradle/github-release.gradle
@@ -66,10 +66,6 @@ def generateChangelogSnippet() {
     return "  " + snippet.trim()
 }
 
-task test2 << {
-    rootProject.version="0.9.0-SNAPSHOT"
-}
-
 task updateReleaseVersionChangelog() << {
     def newVersion = rootProject.version.replaceAll('-SNAPSHOT', '')
     def changelog = rootProject.file('CHANGELOG.md')

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -37,12 +37,7 @@ def checkAndDefaultProperty(prop) {
 
 def checkProperty(prop) {
     if (!project.hasProperty(prop)) {
-        def message = "Add " + prop + " to your ~/.gradle/gradle.properties file."
-        if (isReleaseBuild()) {
-            throw new GradleException(message)
-        } else {
-            logger.warn(message)
-        }
+        logger.warn("Add " + prop + " to your ~/.gradle/gradle.properties file.")
     }
 }
 


### PR DESCRIPTION
Description:
Previous implementation would cache the results of findProperty, we need to use the project version instead, which is updated in the gradle release script.
 