### PR TITLE
add deprecated "onReceivedError" to solve compatibility issue

### DIFF
--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginActivity.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginActivity.java
@@ -22,10 +22,12 @@
 
 package com.uber.sdk.android.core.auth;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
@@ -218,8 +220,27 @@ public class LoginActivity extends Activity {
             this.redirectUri = redirectUri;
         }
 
+        /**
+         * add deprecated member "onReceivedError" to solve compatibility issue when API level < 23
+         * @param view
+         * @param errorCode
+         * @param description
+         * @param failingUrl
+         */
+        @Override
+        public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
+            if(Build.VERSION.SDK_INT<Build.VERSION_CODES.M) {
+                receivedError();
+            }
+        }
+
+        @TargetApi(23)
         @Override
         public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+            receivedError();
+        }
+
+        private void receivedError(){
             onError(AuthenticationError.CONNECTIVITY_ISSUE);
         }
 

--- a/rides-android/src/main/java/com/uber/sdk/android/rides/RideRequestView.java
+++ b/rides-android/src/main/java/com/uber/sdk/android/rides/RideRequestView.java
@@ -22,9 +22,11 @@
 
 package com.uber.sdk.android.rides;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
@@ -261,12 +263,32 @@ public class RideRequestView extends LinearLayout {
             rideRequestWebViewClientCallback = callback;
         }
 
+        /**
+         * add deprecated member "onReceivedError" to solve compatibility issue when API level < 23
+         * @param view
+         * @param errorCode
+         * @param description
+         * @param failingUrl
+         */
+        @Override
+        public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
+            if(Build.VERSION.SDK_INT<Build.VERSION_CODES.M){
+                receivedError();
+            }
+        }
+
+        @TargetApi(23)
         @Override
         public void onReceivedError(
                 WebView view, WebResourceRequest request, WebResourceError error) {
+            receivedError();
+        }
+
+        private void receivedError(){
             rideRequestWebViewClientCallback.onErrorParsed(RideRequestViewError.CONNECTIVITY_ISSUE);
         }
 
+        @TargetApi(23)
         @Override
         public void onReceivedHttpError(WebView view, WebResourceRequest request, WebResourceResponse errorResponse) {
             // This is a no-op necessary for testing as robolectric only supports up


### PR DESCRIPTION
Description: reserve both new and deprecated "onReceivedError" to ensure it works well in all API level.

Related issue(s): #105 