### PR TITLE
Adding support to SSO with Uber Eats

### DIFF
--- a/core-android/src/main/java/com/uber/sdk/android/core/SupportedAppType.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/SupportedAppType.java
@@ -1,0 +1,14 @@
+package com.uber.sdk.android.core;
+
+import android.content.Context;
+
+/**
+ * List of Apps that may support functionality of the SDK.  Not all functionality is supported by all apps.
+ * <p>
+ * To check if this app is installed use
+ * {@link com.uber.sdk.android.core.utils.AppProtocol#isInstalled(Context, SupportedAppType)}.
+ */
+public enum SupportedAppType {
+    UBER,
+    UBER_EATS,
+}

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/AccessTokenManagerTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/AccessTokenManagerTest.java
@@ -33,9 +33,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.robolectric.RuntimeEnvironment;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -266,7 +268,8 @@ public class AccessTokenManagerTest extends RobolectricTestBase {
         assertAccessTokensEqual(ACCESS_TOKEN_SECOND, tokenPreferences.getAccessToken(CUSTOM_ACCESS_TOKEN_KEY));
     }
 
-    private void assertAccessTokensEqual(AccessToken accessTokenExpected, AccessToken accessTokenActual) {
+    private void assertAccessTokensEqual(AccessToken accessTokenExpected, @Nullable AccessToken accessTokenActual) {
+        assertNotNull(accessTokenActual);
         assertEquals(accessTokenExpected.getExpiresIn(),
                 accessTokenActual.getExpiresIn());
         assertEquals(accessTokenExpected.getToken(), accessTokenActual.getToken());

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginManagerTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginManagerTest.java
@@ -138,7 +138,7 @@ public class LoginManagerTest extends RobolectricTestBase {
 
     @Test
     public void login_withLegacyModeBlocking_shouldNotLogin() {
-        stubAppInstalled(packageManager, AppProtocol.UBER_PACKAGE_NAMES[0], SsoDeeplink.MIN_VERSION_SUPPORTED);
+        stubAppInstalled(packageManager, AppProtocol.UBER_PACKAGE_NAMES[0], SsoDeeplink.MIN_UBER_RIDES_VERSION_SUPPORTED);
         when(legacyUriRedirectHandler.checkValidState(eq(activity), eq(loginManager))).thenReturn(false);
         loginManager.login(activity);
 
@@ -147,7 +147,7 @@ public class LoginManagerTest extends RobolectricTestBase {
 
     @Test
     public void login_withLegacyModeNotBlocking_shouldLogin() {
-        stubAppInstalled(packageManager, AppProtocol.UBER_PACKAGE_NAMES[0], SsoDeeplink.MIN_VERSION_SUPPORTED);
+        stubAppInstalled(packageManager, AppProtocol.UBER_PACKAGE_NAMES[0], SsoDeeplink.MIN_UBER_RIDES_VERSION_SUPPORTED);
         when(legacyUriRedirectHandler.checkValidState(eq(activity), eq(loginManager))).thenReturn(true);
         loginManager.login(activity);
 
@@ -156,7 +156,7 @@ public class LoginManagerTest extends RobolectricTestBase {
 
     @Test
     public void loginWithAppInstalledPrivilegedScopes_shouldLaunchIntent() {
-        stubAppInstalled(packageManager, AppProtocol.UBER_PACKAGE_NAMES[0], SsoDeeplink.MIN_VERSION_SUPPORTED);
+        stubAppInstalled(packageManager, AppProtocol.UBER_PACKAGE_NAMES[0], SsoDeeplink.MIN_UBER_RIDES_VERSION_SUPPORTED);
 
         loginManager.login(activity);
 
@@ -174,7 +174,7 @@ public class LoginManagerTest extends RobolectricTestBase {
         loginManager = new LoginManager(accessTokenStorage, callback,
                 sessionConfiguration, REQUEST_CODE);
 
-        stubAppInstalled(packageManager, AppProtocol.UBER_PACKAGE_NAMES[0], SsoDeeplink.MIN_VERSION_SUPPORTED);
+        stubAppInstalled(packageManager, AppProtocol.UBER_PACKAGE_NAMES[0], SsoDeeplink.MIN_UBER_RIDES_VERSION_SUPPORTED);
 
         loginManager.login(activity);
 

--- a/core-android/src/test/java/com/uber/sdk/android/core/utils/AppProtocolTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/utils/AppProtocolTest.java
@@ -4,9 +4,7 @@ import android.app.Activity;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
-
 import com.uber.sdk.android.core.RobolectricTestBase;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -61,35 +59,35 @@ public class AppProtocolTest extends RobolectricTestBase {
     @Mock
     PackageInfo packageInfo;
 
-    Activity activity;
-    AppProtocol appProtocol;
+    private Activity activity;
+    private AppProtocol appProtocol;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         activity = spy(Robolectric.setupActivity(Activity.class));
         appProtocol = new AppProtocol();
     }
 
     @Test
-    public void validateSignature_whenValid_returnsTrue() throws Exception {
+    public void validateSignature_whenValid_returnsTrue() {
         stubAppSignature(GOOD_SIGNATURE);
-        assertTrue(appProtocol.validateSignature(activity, AppProtocol.UBER_PACKAGE_NAMES[0]));
+        assertTrue(appProtocol.validateSignature(activity, AppProtocol.RIDER_PACKAGE_NAMES[0]));
     }
 
     @Test
-    public void validateSignature_whenInvalid_returnsFalse() throws Exception {
+    public void validateSignature_whenInvalid_returnsFalse() {
         stubAppSignature(BAD_SIGNATURE);
-        assertFalse(appProtocol.validateSignature(activity, AppProtocol.UBER_PACKAGE_NAMES[0]));
+        assertFalse(appProtocol.validateSignature(activity, AppProtocol.RIDER_PACKAGE_NAMES[0]));
     }
 
     @Test
-    public void validateSignature_whenGoodAndBad_returnsFalse() throws Exception {
+    public void validateSignature_whenGoodAndBad_returnsFalse() {
         stubAppSignature(GOOD_SIGNATURE, BAD_SIGNATURE);
-        assertFalse(appProtocol.validateSignature(activity, AppProtocol.UBER_PACKAGE_NAMES[0]));
+        assertFalse(appProtocol.validateSignature(activity, AppProtocol.RIDER_PACKAGE_NAMES[0]));
     }
 
     @Test
-    public void getApplicationSignature_whenValidPackageSignature_shouldSucceed() throws Exception {
+    public void getApplicationSignature_whenValidPackageSignature_shouldSucceed() {
         stubAppSignature(GOOD_SIGNATURE);
         assertThat(appProtocol.getAppSignature(activity)).isEqualTo(GOOD_HASH);
     }
@@ -99,7 +97,7 @@ public class AppProtocolTest extends RobolectricTestBase {
         stubAppSignature(GOOD_SIGNATURE);
         final Throwable throwable = new PackageManager.NameNotFoundException();
         doThrow(throwable).when(packageManager)
-                .getPackageInfo(AppProtocol.UBER_PACKAGE_NAMES[0], PackageManager.GET_SIGNATURES);
+                .getPackageInfo(AppProtocol.RIDER_PACKAGE_NAMES[0], PackageManager.GET_SIGNATURES);
 
         assertThat(appProtocol.getAppSignature(activity)).isNull();
     }
@@ -107,16 +105,16 @@ public class AppProtocolTest extends RobolectricTestBase {
     @Test
     public void getPackageSignature_whenNullPackageInfo_shouldReturnNull() throws Exception {
         stubAppSignature(GOOD_SIGNATURE);
-        when(packageManager.getPackageInfo(AppProtocol.UBER_PACKAGE_NAMES[0], PackageManager.GET_SIGNATURES))
+        when(packageManager.getPackageInfo(AppProtocol.RIDER_PACKAGE_NAMES[0], PackageManager.GET_SIGNATURES))
                 .thenReturn(null);
 
         assertThat(appProtocol.getAppSignature(activity)).isNull();
     }
 
     @Test
-    public void getPackageSignature_whenEmptyPackageInfo_shouldReturnNull() throws Exception {
+    public void getPackageSignature_whenEmptyPackageInfo_shouldReturnNull() {
         stubAppSignature(GOOD_SIGNATURE);
-        packageInfo.signatures = new Signature[] {};
+        packageInfo.signatures = new Signature[]{};
 
         assertThat(appProtocol.getAppSignature(activity)).isNull();
     }
@@ -132,8 +130,8 @@ public class AppProtocolTest extends RobolectricTestBase {
         assertThat(appProtocol.getAppSignature(activity)).isNull();
     }
 
-    private void stubAppSignature(String... sig) throws Exception {
-        when(activity.getPackageName()).thenReturn(AppProtocol.UBER_PACKAGE_NAMES[0]);
+    private void stubAppSignature(String... sig) {
+        when(activity.getPackageName()).thenReturn(AppProtocol.RIDER_PACKAGE_NAMES[0]);
         when(activity.getPackageManager()).thenReturn(packageManager);
 
         Signature[] signatures = new Signature[sig.length];
@@ -144,7 +142,7 @@ public class AppProtocolTest extends RobolectricTestBase {
         packageInfo.signatures = signatures;
 
         try {
-            when(packageManager.getPackageInfo(eq(AppProtocol.UBER_PACKAGE_NAMES[0]), anyInt()))
+            when(packageManager.getPackageInfo(eq(AppProtocol.RIDER_PACKAGE_NAMES[0]), anyInt()))
                     .thenReturn(packageInfo);
         } catch (PackageManager.NameNotFoundException e) {
             fail("Unable to mock Package Manager");

--- a/rides-android/src/main/java/com/uber/sdk/android/rides/RideRequestDeeplink.java
+++ b/rides-android/src/main/java/com/uber/sdk/android/rides/RideRequestDeeplink.java
@@ -34,6 +34,7 @@ import com.uber.sdk.android.core.utils.AppProtocol;
 import com.uber.sdk.android.core.utils.CustomTabsHelper;
 import com.uber.sdk.core.client.SessionConfiguration;
 
+import static com.uber.sdk.android.core.SupportedAppType.UBER;
 import static com.uber.sdk.android.core.utils.Preconditions.checkNotNull;
 
 
@@ -76,7 +77,7 @@ public class RideRequestDeeplink implements Deeplink {
 
     @Override
     public boolean isSupported() {
-        return appProtocol.isUberInstalled(context);
+        return appProtocol.isInstalled(context, UBER);
     }
 
     /**
@@ -226,7 +227,7 @@ public class RideRequestDeeplink implements Deeplink {
         Uri.Builder getUriBuilder(@NonNull Context context, @NonNull Deeplink.Fallback
                 fallback) {
             final Uri.Builder builder;
-            if (appProtocol.isUberInstalled(context)) {
+            if (appProtocol.isInstalled(context, UBER)) {
                 if (appProtocol.isAppLinkSupported()) {
                     builder = Uri.parse(Deeplink.APP_LINK_URI).buildUpon();
                 } else {

--- a/rides-android/src/test/java/com/uber/sdk/android/rides/RideRequestDeeplinkTest.java
+++ b/rides-android/src/test/java/com/uber/sdk/android/rides/RideRequestDeeplinkTest.java
@@ -22,19 +22,13 @@
 
 package com.uber.sdk.android.rides;
 
-import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.support.customtabs.CustomTabsIntent;
 
 import com.uber.sdk.android.core.Deeplink;
 import com.uber.sdk.android.core.utils.AppProtocol;
 import com.uber.sdk.android.core.utils.CustomTabsHelper;
-import com.uber.sdk.android.core.utils.PackageManagers;
 import com.uber.sdk.core.client.SessionConfiguration;
 
 import org.junit.Before;
@@ -42,13 +36,10 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
-import org.robolectric.res.builder.RobolectricPackageManager;
-import org.robolectric.shadows.ShadowActivity;
 
 import java.io.IOException;
 
+import static com.uber.sdk.android.core.SupportedAppType.UBER;
 import static com.uber.sdk.android.rides.TestUtils.readUriResourceWithUserAgentParam;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -56,15 +47,12 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.robolectric.Shadows.shadowOf;
 
 /**
  * Tests {@link RideRequestDeeplink}
  */
 public class RideRequestDeeplinkTest extends RobolectricTestBase {
 
-    private static final String UBER_PACKAGE_NAME = "com.ubercab";
-    private static final String CLIENT_ID = "clientId";
     private static final String PRODUCT_ID = "productId";
     private static final Double PICKUP_LAT = 32.1234;
     private static final Double PICKUP_LONG = -122.3456;
@@ -84,7 +72,7 @@ public class RideRequestDeeplinkTest extends RobolectricTestBase {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        when(appProtocol.isUberInstalled(eq(context))).thenReturn(true);
+        when(appProtocol.isInstalled(eq(context), eq(UBER))).thenReturn(true);
         when(appProtocol.isAppLinkSupported()).thenReturn(false);
     }
 
@@ -190,7 +178,6 @@ public class RideRequestDeeplinkTest extends RobolectricTestBase {
                 ("src/test/resources/deeplinkuris/mobile_web_ul_just_client_provided",
                 USER_AGENT_DEEPLINK);
 
-        when(appProtocol.isUberInstalled(eq(context))).thenReturn(true);
         when(appProtocol.isAppLinkSupported()).thenReturn(true);
 
         RideParameters rideParameters = new RideParameters.Builder().build();
@@ -210,7 +197,6 @@ public class RideRequestDeeplinkTest extends RobolectricTestBase {
                 ("src/test/resources/deeplinkuris/just_client_provided",
                         USER_AGENT_DEEPLINK);
 
-        when(appProtocol.isUberInstalled(eq(context))).thenReturn(true);
         when(appProtocol.isAppLinkSupported()).thenReturn(false);
 
         RideParameters rideParameters = new RideParameters.Builder().build();
@@ -229,7 +215,7 @@ public class RideRequestDeeplinkTest extends RobolectricTestBase {
                 ("src/test/resources/deeplinkuris/mobile_web_just_client_provided",
                         USER_AGENT_DEEPLINK);
 
-        when(appProtocol.isUberInstalled(eq(context))).thenReturn(false);
+        when(appProtocol.isInstalled(eq(context), eq(UBER))).thenReturn(false);
 
         RideParameters rideParameters = new RideParameters.Builder().build();
         RideRequestDeeplink rideRequestDeeplink = new RideRequestDeeplink.Builder(context)
@@ -248,7 +234,7 @@ public class RideRequestDeeplinkTest extends RobolectricTestBase {
                 ("src/test/resources/deeplinkuris/mobile_web_ul_just_client_provided",
                         USER_AGENT_DEEPLINK);
 
-        when(appProtocol.isUberInstalled(eq(context))).thenReturn(false);
+        when(appProtocol.isInstalled(eq(context), eq(UBER))).thenReturn(false);
 
         RideParameters rideParameters = new RideParameters.Builder().build();
         RideRequestDeeplink rideRequestDeeplink = new RideRequestDeeplink.Builder(context)
@@ -267,7 +253,7 @@ public class RideRequestDeeplinkTest extends RobolectricTestBase {
                 ("src/test/resources/deeplinkuris/mobile_web_ul_just_client_provided",
                         USER_AGENT_DEEPLINK);
 
-        when(appProtocol.isUberInstalled(eq(context))).thenReturn(false);
+        when(appProtocol.isInstalled(eq(context), eq(UBER))).thenReturn(false);
 
         RideParameters rideParameters = new RideParameters.Builder().build();
         RideRequestDeeplink rideRequestDeeplink = new RideRequestDeeplink.Builder(context)


### PR DESCRIPTION
Description:  Introduces `SupportedAppType` to differentiate the API's of `AppProtocol`.  This adds a public API for `AppProtocol.isInstalled(Context, SupportedAppType)`.  

LoginManager's API is unchanged and will attempt to SSO with Uber apps in the order defined by `SupportedAppType`, Uber then Uber Eats.

Some constants were renamed to explicitly define the app they are defined for.

Related issue(s): #130 