### PR TITLE
Update LoginManager to support IETF RFC 8252 compliance

### DIFF
--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginActivity.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginActivity.java
@@ -200,7 +200,7 @@ public class LoginActivity extends Activity {
         }
 
         String redirectUri = sessionConfiguration.getRedirectUri() != null ? sessionConfiguration
-                .getRedirectUri() : getApplicationContext().getPackageName() + "uberauth";
+                .getRedirectUri() : getApplicationContext().getPackageName().concat(".uberauth://redirect");
 
         if (intent.getBooleanExtra(EXTRA_SSO_ENABLED, false)) {
             SsoDeeplink ssoDeeplink = ssoDeeplinkFactory.getSsoDeeplink(this, sessionConfiguration);

--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginManager.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginManager.java
@@ -26,6 +26,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 import com.uber.sdk.android.core.BuildConfig;
 import com.uber.sdk.android.core.SupportedAppType;
@@ -88,9 +89,6 @@ public class LoginManager {
     static final String EXTRA_CODE_RECEIVED = "CODE_RECEIVED";
 
     static final int REQUEST_CODE_LOGIN_DEFAULT = 1001;
-
-    private static final String USER_AGENT = String.format("core-android-v%s-login_manager",
-            BuildConfig.VERSION_NAME);
 
     private final AccessTokenStorage accessTokenStorage;
     private final LoginCallback callback;
@@ -175,22 +173,20 @@ public class LoginManager {
             return;
         }
 
-        SsoDeeplink ssoDeeplink = new SsoDeeplink.Builder(activity)
-                .clientId(sessionConfiguration.getClientId())
-                .scopes(sessionConfiguration.getScopes())
-                .customScopes(sessionConfiguration.getCustomScopes())
-                .productFlowPriority(productFlowPriority)
-                .activityRequestCode(requestCode)
-                .build();
+        SsoDeeplink ssoDeeplink = getSsoDeeplink(activity);
 
-        if (ssoDeeplink.isSupported()) {
-            ssoDeeplink.execute();
+        if (ssoDeeplink.isSupported(SsoDeeplink.FlowVersion.REDIRECT_TO_SDK)) {
+            Intent intent = LoginActivity.newIntent(activity, sessionConfiguration, ResponseType.TOKEN,
+                    false, true, true);
+            activity.startActivityForResult(intent, requestCode);
+        } else if (ssoDeeplink.isSupported(SsoDeeplink.FlowVersion.DEFAULT)) {
+            ssoDeeplink.execute(SsoDeeplink.FlowVersion.DEFAULT);
         } else if (isAuthCodeFlowEnabled()) {
             loginForAuthorizationCode(activity);
-        } else if (!AuthUtils.isPrivilegeScopeRequired(sessionConfiguration.getScopes())) {
-            loginForImplicitGrant(activity);
         } else {
-            redirectToInstallApp(activity);
+            Intent intent = LoginActivity.newIntent(activity, sessionConfiguration, ResponseType.TOKEN,
+                    legacyUriRedirectHandler.isLegacyMode(), false, true);
+            activity.startActivityForResult(intent, requestCode);
         }
     }
 
@@ -199,6 +195,7 @@ public class LoginManager {
      *
      * @param activity to start Activity on.
      */
+    @Deprecated
     public void loginForImplicitGrant(@NonNull Activity activity) {
 
         if (!legacyUriRedirectHandler.checkValidState(activity, this)) {
@@ -365,10 +362,6 @@ public class LoginManager {
         return authCodeFlowEnabled;
     }
 
-    private void redirectToInstallApp(@NonNull Activity activity) {
-        new SignupDeeplink(activity, sessionConfiguration.getClientId(), USER_AGENT).execute();
-    }
-
     /**
      * {@link Activity} result handler to be called from starting {@link Activity}. Stores {@link AccessToken} and
      * notifies consumer callback of login result.
@@ -392,6 +385,22 @@ public class LoginManager {
         } else if (resultCode == Activity.RESULT_CANCELED) {
             handleResultCancelled(activity, data);
         }
+    }
+
+    /**
+     * Generates the deeplink required to execute the SSO Flow
+     * @param activity the activity to execute the deeplink intent
+     * @return the object that executes the deeplink
+     */
+    @VisibleForTesting
+    SsoDeeplink getSsoDeeplink(@NonNull Activity activity) {
+        return new SsoDeeplink.Builder(activity).clientId(sessionConfiguration.getClientId())
+                .scopes(sessionConfiguration.getScopes())
+                .customScopes(sessionConfiguration.getCustomScopes())
+                .activityRequestCode(requestCode)
+                .redirectUri(sessionConfiguration.getRedirectUri())
+                .productFlowPriority(productFlowPriority)
+                .build();
     }
 
     private void handleResultCancelled(

--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginManager.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginManager.java
@@ -41,6 +41,7 @@ import com.uber.sdk.core.client.ServerTokenSession;
 import com.uber.sdk.core.client.Session;
 import com.uber.sdk.core.client.SessionConfiguration;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 import static com.uber.sdk.core.client.utils.Preconditions.checkNotEmpty;
@@ -176,8 +177,14 @@ public class LoginManager {
         SsoDeeplink ssoDeeplink = getSsoDeeplink(activity);
 
         if (ssoDeeplink.isSupported(SsoDeeplink.FlowVersion.REDIRECT_TO_SDK)) {
-            Intent intent = LoginActivity.newIntent(activity, sessionConfiguration, ResponseType.TOKEN,
-                    false, true, true);
+            Intent intent = LoginActivity.newIntent(
+                    activity,
+                    new ArrayList<>(productFlowPriority),
+                    sessionConfiguration,
+                    ResponseType.TOKEN,
+                    false,
+                    true,
+                    true);
             activity.startActivityForResult(intent, requestCode);
         } else if (ssoDeeplink.isSupported(SsoDeeplink.FlowVersion.DEFAULT)) {
             ssoDeeplink.execute(SsoDeeplink.FlowVersion.DEFAULT);
@@ -231,8 +238,14 @@ public class LoginManager {
             return;
         }
 
-        Intent intent = LoginActivity.newIntent(activity, sessionConfiguration, ResponseType.TOKEN,
-                legacyUriRedirectHandler.isLegacyMode(), false, true);
+        Intent intent = LoginActivity.newIntent(
+                activity,
+                new ArrayList<SupportedAppType>(),
+                sessionConfiguration,
+                ResponseType.TOKEN,
+                legacyUriRedirectHandler.isLegacyMode(),
+                false,
+                true);
         activity.startActivityForResult(intent, requestCode);
     }
 

--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginManager.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginManager.java
@@ -184,9 +184,7 @@ public class LoginManager {
         } else if (isAuthCodeFlowEnabled()) {
             loginForAuthorizationCode(activity);
         } else {
-            Intent intent = LoginActivity.newIntent(activity, sessionConfiguration, ResponseType.TOKEN,
-                    legacyUriRedirectHandler.isLegacyMode(), false, true);
-            activity.startActivityForResult(intent, requestCode);
+            loginForImplicitGrantWithFallback(activity);
         }
     }
 
@@ -219,6 +217,22 @@ public class LoginManager {
 
         Intent intent = LoginActivity.newIntent(activity, sessionConfiguration,
                 ResponseType.CODE, legacyUriRedirectHandler.isLegacyMode());
+        activity.startActivityForResult(intent, requestCode);
+    }
+
+    /**
+     * Login using Implicit Grant, but if requesting privileged scopes, fallback to redirecting the user to the play
+     * store to install the app.
+     *
+     * @param activity to start Activity on.
+     */
+    private void loginForImplicitGrantWithFallback(@NonNull Activity activity) {
+        if (!legacyUriRedirectHandler.checkValidState(activity, this)) {
+            return;
+        }
+
+        Intent intent = LoginActivity.newIntent(activity, sessionConfiguration, ResponseType.TOKEN,
+                legacyUriRedirectHandler.isLegacyMode(), false, true);
         activity.startActivityForResult(intent, requestCode);
     }
 

--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/SsoDeeplink.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/SsoDeeplink.java
@@ -25,6 +25,8 @@ package com.uber.sdk.android.core.auth;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
@@ -60,15 +62,21 @@ public class SsoDeeplink implements Deeplink {
     @VisibleForTesting
     static final int MIN_UBER_EATS_VERSION_SUPPORTED = 1085;
 
+    @VisibleForTesting
+    static final int MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED = 35757;
+
     private static final String URI_QUERY_CLIENT_ID = "client_id";
     private static final String URI_QUERY_SCOPE = "scope";
     private static final String URI_QUERY_PLATFORM = "sdk";
     private static final String URI_QUERY_SDK_VERSION = "sdk_version";
+    private static final String URI_QUERY_FLOW_TYPE = "flow_type";
+    private static final String URI_QUERY_REDIRECT = "redirect_uri";
     private static final String URI_HOST = "connect";
 
     private final Activity activity;
     private final AppProtocol appProtocol;
     private final String clientId;
+    private final String redirectUri;
     private final Collection<Scope> requestedScopes;
     private final Collection<String> requestedCustomScopes;
     private final Collection<SupportedAppType> productFlowPriority;
@@ -78,6 +86,7 @@ public class SsoDeeplink implements Deeplink {
             @NonNull Activity activity,
             @NonNull AppProtocol appProtocol,
             @NonNull String clientId,
+            @NonNull String redirectUri,
             @NonNull Collection<Scope> requestedScopes,
             @NonNull Collection<String> requestedCustomScopes,
             @NonNull Collection<SupportedAppType> productFlowPriority,
@@ -85,6 +94,7 @@ public class SsoDeeplink implements Deeplink {
         this.activity = activity;
         this.appProtocol = appProtocol;
         this.clientId = clientId;
+        this.redirectUri = redirectUri;
         this.requestCode = requestCode;
         this.requestedScopes = requestedScopes;
         this.requestedCustomScopes = requestedCustomScopes;
@@ -92,64 +102,104 @@ public class SsoDeeplink implements Deeplink {
     }
 
     /**
-     * Start {@link Activity#startActivityForResult(Intent, int)} with the right configurations. Use {@link Builder}
-     * to instantiate the object.
+     * {@code flowVersion} defaults to {@link FlowVersion#DEFAULT}
      *
-     * @throws IllegalStateException if compatible Uber app is not installed. Use {@link #isSupported()} to check.
+     * @see #execute(FlowVersion)
      */
     @Override
     public void execute() {
-        checkState(isSupported(), "Single sign on is not supported on the device. " +
+        execute(FlowVersion.DEFAULT);
+    }
+
+    /**
+     * Starts the deeplink with the configuration options specified by this object. Use {@link Builder} to construct
+     * an instance.
+     *
+     * @param flowVersion specifies which client implementation to use for handling the response to the SSO request
+     * @throws IllegalStateException if compatible Uber app is not installed or the deeplink is incorrectly configured.
+     * Use {@link #isSupported()} to check.
+     */
+    void execute(@NonNull FlowVersion flowVersion) {
+        checkState(isSupported(flowVersion), "Single sign on is not supported on the device. " +
                 "Please install or update to the latest version of Uber app.");
 
         Intent intent = new Intent(Intent.ACTION_VIEW);
-        final Uri deepLinkUri = createSsoUri();
+        final Uri deepLinkUri = createSsoUri(flowVersion);
         intent.setData(deepLinkUri);
 
         List<PackageInfo> validatedPackages = new ArrayList<>();
         if (productFlowPriority.isEmpty()) {
             validatedPackages.addAll(
-                    appProtocol.getInstalledPackages(activity, UBER, getSupportedAppVersion(UBER)));
+                    appProtocol.getInstalledPackages(activity, UBER, getSupportedAppVersion(UBER, flowVersion)));
         } else {
             for (SupportedAppType supportedAppType : productFlowPriority) {
                 validatedPackages.addAll(appProtocol.getInstalledPackages(
-                        activity, supportedAppType, getSupportedAppVersion(supportedAppType)));
+                        activity, supportedAppType, getSupportedAppVersion(supportedAppType, flowVersion)));
             }
         }
 
         if (!validatedPackages.isEmpty()) {
             intent.setPackage(validatedPackages.get(0).packageName);
         }
-        activity.startActivityForResult(intent, requestCode);
+        if (flowVersion == FlowVersion.DEFAULT) {
+            activity.startActivityForResult(intent, requestCode);
+        } else {
+            activity.startActivity(intent);
+        }
     }
 
-    private Uri createSsoUri() {
+    private Uri createSsoUri(@NonNull FlowVersion flowVersion) {
         String scopes = AuthUtils.scopeCollectionToString(requestedScopes);
         if (!requestedCustomScopes.isEmpty()) {
             scopes = AuthUtils.mergeScopeStrings(scopes,
                     AuthUtils.customScopeCollectionToString(requestedCustomScopes));
         }
-        return new Uri.Builder().scheme(Deeplink.DEEPLINK_SCHEME)
+        Uri.Builder uriBuilder = new Uri.Builder().scheme(Deeplink.DEEPLINK_SCHEME)
                 .authority(URI_HOST)
                 .appendQueryParameter(URI_QUERY_CLIENT_ID, clientId)
                 .appendQueryParameter(URI_QUERY_SCOPE, scopes)
                 .appendQueryParameter(URI_QUERY_PLATFORM, AppProtocol.PLATFORM)
-                .appendQueryParameter(URI_QUERY_SDK_VERSION, BuildConfig.VERSION_NAME)
-                .build();
+                .appendQueryParameter(URI_QUERY_FLOW_TYPE, flowVersion.name())
+                .appendQueryParameter(URI_QUERY_REDIRECT, redirectUri)
+                .appendQueryParameter(URI_QUERY_SDK_VERSION, BuildConfig.VERSION_NAME);
+        return uriBuilder.build();
+    }
+
+    /**
+     * {@code flowVersion} defaults to {@link FlowVersion#DEFAULT}
+     *
+     * @see #isSupported(FlowVersion)
+     */
+    @Override
+    public boolean isSupported() {
+        return isSupported(FlowVersion.DEFAULT);
     }
 
     /**
      * Check if SSO deep linking is supported in this device.
      *
-     * @return true if package name and minimum version conditions are met.
+     * @param flowVersion specifies which client implementation to validate
+     * @return true if package name, minimum version, and redirect uri requirements for flowVersion are met
      */
-    @Override
-    public boolean isSupported() {
+    boolean isSupported(@NonNull FlowVersion flowVersion) {
+        if (flowVersion == FlowVersion.REDIRECT_TO_SDK) {
+            Intent redirectIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(redirectUri));
+            redirectIntent.setPackage(activity.getPackageName());
+            List<ResolveInfo> resolveInfoList = activity.getPackageManager().queryIntentActivities(
+                    redirectIntent, PackageManager.MATCH_DEFAULT_ONLY);
+            if (resolveInfoList.isEmpty()) {
+                return false;
+            }
+        }
+
         if (productFlowPriority.isEmpty()) {
-            return appProtocol.isInstalled(activity, UBER, getSupportedAppVersion(UBER));
+            return appProtocol.isInstalled(activity, UBER, getSupportedAppVersion(UBER, flowVersion));
         } else {
             for (SupportedAppType supportedAppType : productFlowPriority) {
-                if (appProtocol.isInstalled(activity, supportedAppType, getSupportedAppVersion(supportedAppType))) {
+                if (appProtocol.isInstalled(
+                        activity,
+                        supportedAppType,
+                        getSupportedAppVersion(supportedAppType, flowVersion))) {
                     return true;
                 }
             }
@@ -157,9 +207,11 @@ public class SsoDeeplink implements Deeplink {
         }
     }
 
-    private static int getSupportedAppVersion(SupportedAppType supportedAppType) {
+    private static int getSupportedAppVersion(SupportedAppType supportedAppType, FlowVersion flowVersion) {
         if (UBER == supportedAppType) {
-            return MIN_UBER_RIDES_VERSION_SUPPORTED;
+            return flowVersion == FlowVersion.REDIRECT_TO_SDK
+                    ? MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED
+                    : MIN_UBER_RIDES_VERSION_SUPPORTED;
         } else if (UBER_EATS == supportedAppType) {
             return MIN_UBER_EATS_VERSION_SUPPORTED;
         }
@@ -171,6 +223,7 @@ public class SsoDeeplink implements Deeplink {
         private final Activity activity;
         private AppProtocol appProtocol;
         private String clientId;
+        private String redirectUri;
         private Collection<Scope> requestedScopes;
         private Collection<String> requestedCustomScopes;
         private Collection<SupportedAppType> productFlowPriority;
@@ -216,6 +269,11 @@ public class SsoDeeplink implements Deeplink {
             return this;
         }
 
+        Builder redirectUri(@NonNull String redirectUri) {
+            this.redirectUri = redirectUri;
+            return this;
+        }
+
         public SsoDeeplink build() {
             checkNotNull(clientId, "Client Id must be set");
 
@@ -237,13 +295,26 @@ public class SsoDeeplink implements Deeplink {
                 productFlowPriority = new ArrayList<>();
             }
 
+            if (redirectUri == null) {
+                redirectUri = activity.getPackageName().concat(".uberauth://redirect");
+            }
+
             return new SsoDeeplink(activity,
                     appProtocol,
                     clientId,
+                    redirectUri,
                     requestedScopes,
                     requestedCustomScopes,
                     productFlowPriority,
                     requestCode);
         }
+    }
+
+    /**
+     * Defines which client implementation of the SSO flow to use. This determines how the response from the SSO
+     * request is returned to the calling application.
+     */
+    enum FlowVersion {
+        DEFAULT, REDIRECT_TO_SDK
     }
 }

--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/SsoDeeplinkFactory.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/SsoDeeplinkFactory.java
@@ -1,0 +1,16 @@
+package com.uber.sdk.android.core.auth;
+
+import android.app.Activity;
+import com.uber.sdk.core.client.SessionConfiguration;
+
+public class SsoDeeplinkFactory {
+
+    SsoDeeplink getSsoDeeplink(Activity activity, SessionConfiguration sessionConfiguration) {
+        return new SsoDeeplink.Builder(activity)
+                .clientId(sessionConfiguration.getClientId())
+                .scopes(sessionConfiguration.getScopes())
+                .customScopes(sessionConfiguration.getCustomScopes())
+                .redirectUri(sessionConfiguration.getRedirectUri())
+                .build();
+    }
+}

--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/SsoDeeplinkFactory.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/SsoDeeplinkFactory.java
@@ -1,16 +1,23 @@
 package com.uber.sdk.android.core.auth;
 
 import android.app.Activity;
+import com.uber.sdk.android.core.SupportedAppType;
 import com.uber.sdk.core.client.SessionConfiguration;
+
+import java.util.ArrayList;
 
 public class SsoDeeplinkFactory {
 
-    SsoDeeplink getSsoDeeplink(Activity activity, SessionConfiguration sessionConfiguration) {
+    SsoDeeplink getSsoDeeplink(
+            Activity activity,
+            ArrayList<SupportedAppType> productPriority,
+            SessionConfiguration sessionConfiguration) {
         return new SsoDeeplink.Builder(activity)
                 .clientId(sessionConfiguration.getClientId())
                 .scopes(sessionConfiguration.getScopes())
                 .customScopes(sessionConfiguration.getCustomScopes())
                 .redirectUri(sessionConfiguration.getRedirectUri())
+                .productFlowPriority(productPriority)
                 .build();
     }
 }

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginActivityTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginActivityTest.java
@@ -26,21 +26,30 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 
+import android.support.customtabs.CustomTabsIntent;
+import com.google.common.collect.Sets;
 import com.uber.sdk.android.core.RobolectricTestBase;
+import com.uber.sdk.android.core.utils.CustomTabsHelper;
 import com.uber.sdk.core.auth.AccessToken;
 import com.uber.sdk.core.auth.Scope;
 import com.uber.sdk.core.client.SessionConfiguration;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.robolectric.Robolectric;
+import org.robolectric.Shadows;
 import org.robolectric.shadows.ShadowActivity;
+import org.robolectric.shadows.ShadowWebView;
 import org.robolectric.util.ActivityController;
+
+import java.util.Set;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
 import static org.robolectric.Shadows.shadowOf;
 
 /**
@@ -51,18 +60,232 @@ public class LoginActivityTest extends RobolectricTestBase {
     private static final String REDIRECT_URI = "localHost1234";
     private static final String CLIENT_ID = "clientId1234";
     private static final String CODE = "auth123Code";
+    private static final Set<Scope> GENERAL_SCOPES = Sets.newHashSet(Scope.HISTORY, Scope.PROFILE);
+    private static final Set<Scope> MIXED_SCOPES = Sets.newHashSet(Scope.REQUEST, Scope.PROFILE, Scope.PAYMENT_METHODS);
+    private static final String SIGNUP_DEEPLINK_URL =  "https://m.uber.com/sign-up?client_id=" + CLIENT_ID + "&user-agent=" + LoginActivity.USER_AGENT;
+
     private LoginActivity loginActivity;
+    private SessionConfiguration loginConfiguration;
+
+    @Mock
+    SsoDeeplink ssoDeeplink;
+
+    @Mock
+    SsoDeeplinkFactory ssoDeeplinkFactory;
+
+    @Mock
+    CustomTabsHelper customTabsHelper;
 
     @Before
     public void setup() {
-        SessionConfiguration loginConfiguration = new SessionConfiguration.Builder().setClientId(CLIENT_ID).setRedirectUri(REDIRECT_URI).build();
+        loginConfiguration = new SessionConfiguration.Builder()
+                .setClientId(CLIENT_ID)
+                .setRedirectUri(REDIRECT_URI)
+                .setScopes(GENERAL_SCOPES)
+                .build();
 
         Intent data = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration, ResponseType.TOKEN);
-        loginActivity = Robolectric.buildActivity(LoginActivity.class).withIntent(data).create().get();
+        loginActivity = Robolectric.buildActivity(LoginActivity.class).withIntent(data).get();
+
+        when(ssoDeeplinkFactory.getSsoDeeplink(any(LoginActivity.class), any(SessionConfiguration.class))).thenReturn(ssoDeeplink);
     }
 
     @Test
-    public void onLoginLoad_whenAccessTokenGenerated_shouldReturnAccessTokenResult() {
+    public void onLoginLoad_withEmptySessionConfiguration_shouldReturnErrorResultIntent() {
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class);
+        controller.create();
+
+        ShadowActivity shadowActivity = shadowOf(controller.get());
+
+        assertThat(shadowActivity.getResultCode()).isEqualTo(Activity.RESULT_CANCELED);
+        assertThat(shadowActivity.getResultIntent()).isNotNull();
+        assertThat(getErrorFromIntent(shadowActivity.getResultIntent()))
+                .isEqualTo(AuthenticationError.INVALID_PARAMETERS);
+        assertThat(shadowActivity.isFinishing()).isTrue();
+    }
+
+    @Test
+    public void onLoginLoad_withEmptyScopes_shouldReturnErrorResultIntent() {
+        Intent intent = new Intent();
+        intent.putExtra(LoginActivity.EXTRA_SESSION_CONFIGURATION, new SessionConfiguration.Builder().setClientId(CLIENT_ID).build());
+
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class)
+                .withIntent(intent)
+                .create();
+
+        ShadowActivity shadowActivity = shadowOf(controller.get());
+
+        assertThat(shadowActivity.getResultCode()).isEqualTo(Activity.RESULT_CANCELED);
+        assertThat(shadowActivity.getResultIntent()).isNotNull();
+        assertThat(getErrorFromIntent(shadowActivity.getResultIntent()))
+                .isEqualTo(AuthenticationError.INVALID_SCOPE);
+        assertThat(shadowActivity.isFinishing()).isTrue();
+    }
+
+    @Test
+    public void onLoginLoad_withNullResponseType_shouldReturnErrorResultIntent() {
+        Intent intent = new Intent();
+        intent.putExtra(LoginActivity.EXTRA_SESSION_CONFIGURATION, loginConfiguration);
+        intent.putExtra(LoginActivity.EXTRA_RESPONSE_TYPE, (ResponseType) null);
+
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class)
+                .withIntent(intent)
+                .create();
+
+        ShadowActivity shadowActivity = shadowOf(controller.get());
+
+        assertThat(shadowActivity.getResultCode()).isEqualTo(Activity.RESULT_CANCELED);
+        assertThat(shadowActivity.getResultIntent()).isNotNull();
+        assertThat(getErrorFromIntent(shadowActivity.getResultIntent()))
+                .isEqualTo(AuthenticationError.INVALID_RESPONSE_TYPE);
+        assertThat(shadowActivity.isFinishing()).isTrue();
+    }
+
+    @Test
+    public void onLoginLoad_withSsoEnabled_andSupported_shouldExecuteSsoDeeplink() {
+        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
+                ResponseType.TOKEN, false, true, true);
+
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).withIntent(intent);
+        loginActivity = controller.get();
+        loginActivity.ssoDeeplinkFactory = ssoDeeplinkFactory;
+
+        when(ssoDeeplink.isSupported(SsoDeeplink.FlowVersion.REDIRECT_TO_SDK)).thenReturn(true);
+
+        controller.create();
+
+        verify(ssoDeeplink).execute(SsoDeeplink.FlowVersion.REDIRECT_TO_SDK);
+    }
+
+    @Test
+    public void onLoginLoad_withSsoEnabled_andNotSupported_shouldReturnErrorResultIntent() {
+        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
+                ResponseType.TOKEN, false, true, true);
+
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).withIntent(intent);
+        loginActivity = controller.get();
+        loginActivity.ssoDeeplinkFactory = ssoDeeplinkFactory;
+        ShadowActivity shadowActivity = shadowOf(loginActivity);
+        when(ssoDeeplink.isSupported(SsoDeeplink.FlowVersion.REDIRECT_TO_SDK)).thenReturn(false);
+
+        controller.create();
+
+        assertThat(shadowActivity.getResultCode()).isEqualTo(Activity.RESULT_CANCELED);
+        assertThat(shadowActivity.getResultIntent()).isNotNull();
+        assertThat(getErrorFromIntent(shadowActivity.getResultIntent()))
+                .isEqualTo(AuthenticationError.INVALID_REDIRECT_URI);
+        assertThat(shadowActivity.isFinishing()).isTrue();
+    }
+
+    @Test
+    public void onLoginLoad_withResponseTypeCode_andForceWebview_shouldLoadWebview() {
+        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
+                ResponseType.CODE, true);
+
+        loginActivity = Robolectric.buildActivity(LoginActivity.class).withIntent(intent).create().get();
+        ShadowWebView webview = Shadows.shadowOf(loginActivity.webView);
+
+        String expectedUrl = AuthUtils.buildUrl(REDIRECT_URI, ResponseType.CODE, loginConfiguration);
+        assertThat(webview.getLastLoadedUrl()).isEqualTo(expectedUrl);
+    }
+
+    @Test
+    public void onLoginLoad_withResponseTypeCode_andNotForceWebview_shouldLoadChrometab() {
+        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
+                ResponseType.CODE, false);
+
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).withIntent(intent);
+        loginActivity = controller.get();
+        loginActivity.customTabsHelper = customTabsHelper;
+        controller.create();
+
+        String expectedUrl = AuthUtils.buildUrl(REDIRECT_URI, ResponseType.CODE, loginConfiguration);
+        verify(customTabsHelper).openCustomTab(any(LoginActivity.class), any(CustomTabsIntent.class),
+                eq(Uri.parse(expectedUrl)), any(CustomTabsHelper.BrowserFallback.class));
+    }
+
+    @Test
+    public void onLoginLoad_withResponseTypeToken_andForceWebview_andGeneralScopes_shouldLoadWebview() {
+        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
+                ResponseType.TOKEN, true);
+
+        loginActivity = Robolectric.buildActivity(LoginActivity.class).withIntent(intent).create().get();
+        ShadowWebView webview = Shadows.shadowOf(loginActivity.webView);
+
+        String expectedUrl = AuthUtils.buildUrl(REDIRECT_URI, ResponseType.TOKEN, loginConfiguration);
+        assertThat(webview.getLastLoadedUrl()).isEqualTo(expectedUrl);
+    }
+
+    @Test
+    public void onLoginLoad_withResponseTypeToken_andNotForceWebview_andGeneralScopes_shouldLoadChrometab() {
+        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
+                ResponseType.TOKEN, false);
+
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).withIntent(intent);
+        loginActivity = controller.get();
+        loginActivity.customTabsHelper = customTabsHelper;
+        controller.create();
+
+        String expectedUrl = AuthUtils.buildUrl(REDIRECT_URI, ResponseType.TOKEN, loginConfiguration);
+        verify(customTabsHelper).openCustomTab(any(LoginActivity.class), any(CustomTabsIntent.class),
+                eq(Uri.parse(expectedUrl)), any(CustomTabsHelper.BrowserFallback.class));
+    }
+
+    @Test
+    public void onLoginLoad_withResponseTypeToken_andForceWebview_andPrivilegedScopes_andRedirectToPlayStoreDisabled_shouldLoadWebview() {
+        loginConfiguration = new SessionConfiguration.Builder()
+                .setClientId(CLIENT_ID)
+                .setRedirectUri(REDIRECT_URI)
+                .setScopes(MIXED_SCOPES)
+                .build();
+        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
+                ResponseType.TOKEN, true);
+
+        loginActivity = Robolectric.buildActivity(LoginActivity.class).withIntent(intent).create().get();
+        ShadowWebView webview = Shadows.shadowOf(loginActivity.webView);
+
+        String expectedUrl = AuthUtils.buildUrl(REDIRECT_URI, ResponseType.TOKEN, loginConfiguration);
+        assertThat(webview.getLastLoadedUrl()).isEqualTo(expectedUrl);
+    }
+
+    @Test
+    public void onLoginLoad_withResponseTypeToken_andNotForceWebview_andPrivilegedScopes_andRedirectToPlayStoreDisabled_shouldLoadChrometab() {
+        loginConfiguration = new SessionConfiguration.Builder()
+                .setClientId(CLIENT_ID)
+                .setRedirectUri(REDIRECT_URI)
+                .setScopes(MIXED_SCOPES)
+                .build();
+        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
+                ResponseType.TOKEN, false);
+
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).withIntent(intent);
+        loginActivity = controller.get();
+        loginActivity.customTabsHelper = customTabsHelper;
+        controller.create();
+
+        String expectedUrl = AuthUtils.buildUrl(REDIRECT_URI, ResponseType.TOKEN, loginConfiguration);
+        verify(customTabsHelper).openCustomTab(any(LoginActivity.class), any(CustomTabsIntent.class),
+                eq(Uri.parse(expectedUrl)), any(CustomTabsHelper.BrowserFallback.class));
+    }
+
+    @Test
+    public void onLoginLoad_withResponseTypeToken_andPrivilegedScopes_andRedirectToPlayStoreEnabled_shouldRedirectToPlayStore() {
+        loginConfiguration = new SessionConfiguration.Builder()
+                .setClientId(CLIENT_ID)
+                .setRedirectUri(REDIRECT_URI)
+                .setScopes(MIXED_SCOPES)
+                .build();
+        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
+                ResponseType.TOKEN, true, false, true);
+
+        ShadowActivity shadowActivity = shadowOf(Robolectric.buildActivity(LoginActivity.class).withIntent(intent).create().get());
+
+        final Intent signupDeeplinkIntent = shadowActivity.peekNextStartedActivity();
+        assertThat(signupDeeplinkIntent.getData().toString()).isEqualTo(SIGNUP_DEEPLINK_URL);
+    }
+
+    @Test
+    public void onTokenReceived_shouldReturnAccessTokenResult() {
         String tokenString = "accessToken1234";
 
         String redirectUrl = REDIRECT_URI + "?access_token=accessToken1234&expires_in=" + 2592000
@@ -85,20 +308,20 @@ public class LoginActivityTest extends RobolectricTestBase {
     }
 
     @Test
-    public void onLoginLoad_whenErrorOccurs_shouldReturnErrorResultIntent() {
+    public void onError_shouldReturnErrorResultIntent() {
         ShadowActivity shadowActivity = shadowOf(loginActivity);
         loginActivity.onError(AuthenticationError.MISMATCHING_REDIRECT_URI);
 
         assertThat(shadowActivity.getResultIntent()).isNotNull();
 
         assertThat(shadowActivity.getResultCode()).isEqualTo(Activity.RESULT_CANCELED);
-        assertThat(getScopeFromIntent(shadowActivity.getResultIntent()))
+        assertThat(getErrorFromIntent(shadowActivity.getResultIntent()))
                 .isEqualTo(AuthenticationError.MISMATCHING_REDIRECT_URI);
         assertThat(shadowActivity.isFinishing()).isTrue();
     }
 
     @Test
-    public void onLoginLoad_whenCodeReturned_shouldReturnErrorResultIntent() {
+    public void onCodeReceived_shouldReturnResultIntentWithCode() {
         ShadowActivity shadowActivity = shadowOf(loginActivity);
 
         String redirectUrl = REDIRECT_URI + "?code=" + CODE;
@@ -112,44 +335,7 @@ public class LoginActivityTest extends RobolectricTestBase {
         assertThat(shadowActivity.isFinishing()).isTrue();
     }
 
-    @Test
-    public void onLoginLoad_withEmptySessionConfiguration_shouldReturnErrorResultIntent() {
-        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class);
-        controller.create();
-
-        ShadowActivity shadowActivity = shadowOf(controller.get());
-
-        assertThat(shadowActivity.getResultCode()).isEqualTo(Activity.RESULT_CANCELED);
-
-        assertThat(shadowActivity.getResultIntent()).isNotNull();
-
-        assertThat(getScopeFromIntent(shadowActivity.getResultIntent()))
-                .isEqualTo(AuthenticationError.UNAVAILABLE);
-        assertThat(shadowActivity.isFinishing()).isTrue();
-    }
-
-    @Test
-    public void onLoginLoad_withEmptyScopes_shouldReturnErrorResultIntent() {
-
-        Intent intent = new Intent();
-        intent.putExtra(LoginActivity.EXTRA_SESSION_CONFIGURATION, new SessionConfiguration.Builder().setClientId("clientId").build());
-
-        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class)
-                .withIntent(intent)
-                .create();
-
-        ShadowActivity shadowActivity = shadowOf(controller.get());
-
-        assertThat(shadowActivity.getResultCode()).isEqualTo(Activity.RESULT_CANCELED);
-
-        assertThat(shadowActivity.getResultIntent()).isNotNull();
-
-        assertThat(getScopeFromIntent(shadowActivity.getResultIntent()))
-                .isEqualTo(AuthenticationError.INVALID_SCOPE);
-        assertThat(shadowActivity.isFinishing()).isTrue();
-    }
-
-    private AuthenticationError getScopeFromIntent(Intent intent) {
+    private AuthenticationError getErrorFromIntent(Intent intent) {
         return AuthenticationError.fromString(intent.getStringExtra(LoginManager.EXTRA_ERROR));
     }
 }

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginActivityTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginActivityTest.java
@@ -27,8 +27,10 @@ import android.content.Intent;
 import android.net.Uri;
 
 import android.support.customtabs.CustomTabsIntent;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.uber.sdk.android.core.RobolectricTestBase;
+import com.uber.sdk.android.core.SupportedAppType;
 import com.uber.sdk.android.core.utils.CustomTabsHelper;
 import com.uber.sdk.core.auth.AccessToken;
 import com.uber.sdk.core.auth.Scope;
@@ -43,8 +45,11 @@ import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowWebView;
 import org.robolectric.util.ActivityController;
 
+import java.util.ArrayList;
 import java.util.Set;
 
+import static com.uber.sdk.android.core.SupportedAppType.UBER;
+import static com.uber.sdk.android.core.SupportedAppType.UBER_EATS;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,6 +69,7 @@ public class LoginActivityTest extends RobolectricTestBase {
     private static final Set<Scope> MIXED_SCOPES = Sets.newHashSet(Scope.REQUEST, Scope.PROFILE, Scope.PAYMENT_METHODS);
     private static final String SIGNUP_DEEPLINK_URL =  "https://m.uber.com/sign-up?client_id=" + CLIENT_ID + "&user-agent=" + LoginActivity.USER_AGENT;
 
+    private final ArrayList<SupportedAppType> productPriority = new ArrayList<>(ImmutableList.of(UBER_EATS, UBER));
     private LoginActivity loginActivity;
     private SessionConfiguration loginConfiguration;
 
@@ -87,7 +93,8 @@ public class LoginActivityTest extends RobolectricTestBase {
         Intent data = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration, ResponseType.TOKEN);
         loginActivity = Robolectric.buildActivity(LoginActivity.class).withIntent(data).get();
 
-        when(ssoDeeplinkFactory.getSsoDeeplink(any(LoginActivity.class), any(SessionConfiguration.class))).thenReturn(ssoDeeplink);
+        when(ssoDeeplinkFactory.getSsoDeeplink(any(LoginActivity.class),
+                eq(productPriority), any(SessionConfiguration.class))).thenReturn(ssoDeeplink);
     }
 
     @Test
@@ -143,8 +150,8 @@ public class LoginActivityTest extends RobolectricTestBase {
 
     @Test
     public void onLoginLoad_withSsoEnabled_andSupported_shouldExecuteSsoDeeplink() {
-        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
-                ResponseType.TOKEN, false, true, true);
+        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), productPriority,
+                loginConfiguration, ResponseType.TOKEN, false, true, true);
 
         ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).withIntent(intent);
         loginActivity = controller.get();
@@ -159,8 +166,8 @@ public class LoginActivityTest extends RobolectricTestBase {
 
     @Test
     public void onLoginLoad_withSsoEnabled_andNotSupported_shouldReturnErrorResultIntent() {
-        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
-                ResponseType.TOKEN, false, true, true);
+        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), productPriority,
+                loginConfiguration, ResponseType.TOKEN, false, true, true);
 
         ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).withIntent(intent);
         loginActivity = controller.get();
@@ -275,8 +282,8 @@ public class LoginActivityTest extends RobolectricTestBase {
                 .setRedirectUri(REDIRECT_URI)
                 .setScopes(MIXED_SCOPES)
                 .build();
-        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
-                ResponseType.TOKEN, true, false, true);
+        Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class),
+                new ArrayList<SupportedAppType>(), loginConfiguration, ResponseType.TOKEN, true, false, true);
 
         ShadowActivity shadowActivity = shadowOf(Robolectric.buildActivity(LoginActivity.class).withIntent(intent).create().get());
 

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/SsoDeeplinkTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/SsoDeeplinkTest.java
@@ -23,21 +23,27 @@
 package com.uber.sdk.android.core.auth;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.uber.sdk.android.core.BuildConfig;
 import com.uber.sdk.android.core.RobolectricTestBase;
-import com.uber.sdk.android.core.SupportedAppType;
 import com.uber.sdk.android.core.utils.AppProtocol;
+
 import com.uber.sdk.core.auth.Scope;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.res.builder.RobolectricPackageManager;
+import org.robolectric.shadows.ShadowResolveInfo;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -46,61 +52,218 @@ import java.util.Set;
 
 import static com.uber.sdk.android.core.SupportedAppType.UBER;
 import static com.uber.sdk.android.core.SupportedAppType.UBER_EATS;
+import static com.uber.sdk.android.core.auth.SsoDeeplink.FlowVersion.DEFAULT;
+import static com.uber.sdk.android.core.auth.SsoDeeplink.FlowVersion.REDIRECT_TO_SDK;
 import static com.uber.sdk.android.core.auth.SsoDeeplink.MIN_UBER_EATS_VERSION_SUPPORTED;
 import static com.uber.sdk.android.core.auth.SsoDeeplink.MIN_UBER_RIDES_VERSION_SUPPORTED;
+import static com.uber.sdk.android.core.auth.SsoDeeplink.MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
 public class SsoDeeplinkTest extends RobolectricTestBase {
 
     private static final String CLIENT_ID = "MYCLIENTID";
     private static final Set<Scope> GENERAL_SCOPES = Sets.newHashSet(Scope.HISTORY, Scope.PROFILE);
     private static final int REQUEST_CODE = 1234;
+    private static final String REDIRECT_URI = "com.example.app://redirect";
 
-    private static final String DEFAULT_REGION =
-            "uber://connect?client_id=MYCLIENTID&scope=profile%20history&sdk=android&sdk_version="
+    private static final String DEFAULT_URI =
+            "uber://connect?client_id=MYCLIENTID&scope=profile%20history&sdk=android&flow_type=DEFAULT"
+                    + "&redirect_uri=com.example.app%3A%2F%2Fredirect&sdk_version="
                     + BuildConfig.VERSION_NAME;
-
     @Mock
     AppProtocol appProtocol;
 
     Activity activity;
 
+    RobolectricPackageManager packageManager;
+
+    ResolveInfo resolveInfo;
+
+    Intent redirectIntent;
+
+    SsoDeeplink ssoDeeplink;
+
     @Before
     public void setUp() {
         activity = spy(Robolectric.setupActivity(Activity.class));
+
+        redirectIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(REDIRECT_URI));
+        redirectIntent.setPackage(activity.getPackageName());
+        resolveInfo = ShadowResolveInfo.newResolveInfo("", activity.getPackageName());
+        packageManager = RuntimeEnvironment.getRobolectricPackageManager();
+        packageManager.addResolveInfoForIntent(redirectIntent, resolveInfo);
+
+        ssoDeeplink = new SsoDeeplink.Builder(activity)
+                .clientId(CLIENT_ID)
+                .scopes(GENERAL_SCOPES)
+                .appProtocol(appProtocol)
+                .activityRequestCode(REQUEST_CODE)
+                .redirectUri(REDIRECT_URI)
+                .build();
     }
 
     @Test
-    public void isSupported_appInstalled_shouldBeTrue() {
-        when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED)).thenReturn(true);
+    public void isSupported_ridesNotInstalled_withoutProductPriority_shouldBeFalse() {
+        when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED)).thenReturn(false);
+
+        assertThat(ssoDeeplink.isSupported()).isFalse();
+
+        verify(appProtocol).isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED);
+        verify(appProtocol, never()).isInstalled(any(Context.class), eq(UBER_EATS), anyInt());
+    }
+
+    @Test
+    public void isSupported_ridesNotInstalled_withoutProductPriority_andRedirectToSdkFlowVersion_shouldBeFalse() {
+        when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED)).thenReturn(false);
+
+        assertThat(ssoDeeplink.isSupported(REDIRECT_TO_SDK)).isFalse();
+
+        verify(appProtocol).isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED);
+        verify(appProtocol, never()).isInstalled(any(Context.class), eq(UBER_EATS), anyInt());
+    }
+
+    @Test
+    public void isSupported_ridesInstalled_withoutProductPriority_shouldBeTrue() {
+        enableSupport(DEFAULT);
+
+        assertThat(ssoDeeplink.isSupported()).isTrue();
+
+        verify(appProtocol).isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED);
+        verify(appProtocol, never()).isInstalled(any(Context.class), eq(UBER_EATS), anyInt());
+    }
+
+    @Test
+    public void isSupported_ridesInstalled_withoutProductPriority_andRedirectToSdkFlowVersion_shouldBeTrue() {
+        enableSupport(REDIRECT_TO_SDK);
+
+        assertThat(ssoDeeplink.isSupported(REDIRECT_TO_SDK)).isTrue();
+
+        verify(appProtocol).isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED);
+        verify(appProtocol, never()).isInstalled(any(Context.class), eq(UBER_EATS), anyInt());
+    }
+
+    @Test
+    public void isSupported_eatsNotInstalled_withEatsProductPriority_shouldBeFalse() {
         when(appProtocol.isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED)).thenReturn(false);
 
-        final SsoDeeplink link = new SsoDeeplink.Builder(activity)
+        ssoDeeplink = new SsoDeeplink.Builder(activity)
                 .clientId(CLIENT_ID)
                 .scopes(GENERAL_SCOPES)
                 .appProtocol(appProtocol)
+                .activityRequestCode(REQUEST_CODE)
+                .redirectUri(REDIRECT_URI)
+                .productFlowPriority(ImmutableList.of(UBER_EATS))
                 .build();
 
-        assertThat(link.isSupported()).isTrue();
+        assertThat(ssoDeeplink.isSupported()).isFalse();
+        assertThat(ssoDeeplink.isSupported(REDIRECT_TO_SDK)).isFalse();
+
+        verify(appProtocol, times(2)).isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED);
+        verify(appProtocol, never()).isInstalled(any(Context.class), eq(UBER), anyInt());
     }
 
     @Test
-    public void isSupported_eatsAppInstalled_withoutProductPriority_shouldBeFalse() {
-        when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED)).thenReturn(false);
+    public void isSupported_eatsInstalled_withEatsProductPriority_shouldBeTrue() {
         when(appProtocol.isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED)).thenReturn(true);
 
-        final SsoDeeplink link = new SsoDeeplink.Builder(activity)
+        ssoDeeplink = new SsoDeeplink.Builder(activity)
                 .clientId(CLIENT_ID)
                 .scopes(GENERAL_SCOPES)
                 .appProtocol(appProtocol)
+                .activityRequestCode(REQUEST_CODE)
+                .redirectUri(REDIRECT_URI)
+                .productFlowPriority(ImmutableList.of(UBER_EATS))
                 .build();
 
-        assertThat(link.isSupported()).isFalse();
+        assertThat(ssoDeeplink.isSupported()).isTrue();
+        assertThat(ssoDeeplink.isSupported(REDIRECT_TO_SDK)).isTrue();
+
+        verify(appProtocol, times(2)).isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED);
+        verify(appProtocol, never()).isInstalled(any(Context.class), eq(UBER), anyInt());
+    }
+
+    @Test
+    public void isSupported_noneInstalled_withCombinedProductPriority_shouldBeFalse() {
+        when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED)).thenReturn(false);
+        when(appProtocol.isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED)).thenReturn(false);
+
+        ssoDeeplink = new SsoDeeplink.Builder(activity)
+                .clientId(CLIENT_ID)
+                .scopes(GENERAL_SCOPES)
+                .appProtocol(appProtocol)
+                .activityRequestCode(REQUEST_CODE)
+                .redirectUri(REDIRECT_URI)
+                .productFlowPriority(ImmutableList.of(UBER, UBER_EATS))
+                .build();
+
+        assertThat(ssoDeeplink.isSupported()).isFalse();
+
+        InOrder orderVerifier = inOrder(appProtocol);
+        orderVerifier.verify(appProtocol).isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED);
+        orderVerifier.verify(appProtocol).isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED);
+    }
+
+    @Test
+    public void isSupported_noneInstalled_withCombinedProductPriority_andRedirectToSdkFlowVersion_shouldBeFalse() {
+        when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED)).thenReturn(false);
+        when(appProtocol.isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED)).thenReturn(false);
+
+        ssoDeeplink = new SsoDeeplink.Builder(activity)
+                .clientId(CLIENT_ID)
+                .scopes(GENERAL_SCOPES)
+                .appProtocol(appProtocol)
+                .activityRequestCode(REQUEST_CODE)
+                .redirectUri(REDIRECT_URI)
+                .productFlowPriority(ImmutableList.of(UBER, UBER_EATS))
+                .build();
+
+        assertThat(ssoDeeplink.isSupported(REDIRECT_TO_SDK)).isFalse();
+
+        InOrder orderVerifier = inOrder(appProtocol);
+        orderVerifier.verify(appProtocol).isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED);
+        orderVerifier.verify(appProtocol).isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED);
+    }
+
+    @Test
+    public void isSupported_bothAppsInstalled_withCombinedProductPriority_shouldBeTrue() {
+        enableSupport(DEFAULT);
+
+        ssoDeeplink = new SsoDeeplink.Builder(activity)
+                .clientId(CLIENT_ID)
+                .scopes(GENERAL_SCOPES)
+                .appProtocol(appProtocol)
+                .activityRequestCode(REQUEST_CODE)
+                .redirectUri(REDIRECT_URI)
+                .productFlowPriority(ImmutableList.of(UBER, UBER_EATS))
+                .build();
+
+        assertThat(ssoDeeplink.isSupported()).isTrue();
+
+        verify(appProtocol).isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED);
+        verify(appProtocol, never()).isInstalled(any(Context.class), eq(UBER_EATS), anyInt());
+    }
+
+    @Test
+    public void isSupported_bothAppsInstalled_withCombinedProductPriority_andRedirectToSdkFlowVersion_shouldBeTrue() {
+        enableSupport(REDIRECT_TO_SDK);
+
+        ssoDeeplink = new SsoDeeplink.Builder(activity)
+                .clientId(CLIENT_ID)
+                .scopes(GENERAL_SCOPES)
+                .appProtocol(appProtocol)
+                .activityRequestCode(REQUEST_CODE)
+                .redirectUri(REDIRECT_URI)
+                .productFlowPriority(ImmutableList.of(UBER, UBER_EATS))
+                .build();
+
+        assertThat(ssoDeeplink.isSupported(REDIRECT_TO_SDK)).isTrue();
+
+        verify(appProtocol).isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED);
+        verify(appProtocol, never()).isInstalled(any(Context.class), eq(UBER_EATS), anyInt());
     }
 
     @Test
@@ -119,74 +282,145 @@ public class SsoDeeplinkTest extends RobolectricTestBase {
     }
 
     @Test
-    public void isSupported_appNotInstalled_shouldBeFalse() {
-        when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED)).thenReturn(false);
+    public void isSupported_withRidesAppInstalled_andDefaultFlowVersion_andAboveMinDefaultFlowVersion_shouldBeTrue() {
+        when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED)).thenReturn(true);
         when(appProtocol.isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED)).thenReturn(false);
 
-        final SsoDeeplink link = new SsoDeeplink.Builder(activity)
-                .clientId(CLIENT_ID)
-                .scopes(GENERAL_SCOPES)
-                .appProtocol(appProtocol)
-                .build();
+        assertThat(ssoDeeplink.isSupported()).isTrue();
 
-        assertThat(link.isSupported()).isFalse();
+        verify(appProtocol).isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED);
     }
 
     @Test
-    public void execute_withInstalledPackage_shouldSetPackage() {
+    public void isSupported_withRedirectToSdkFlowVersion_andCantResolveRedirectIntent_shouldBeFalse() {
+        enableSupport(REDIRECT_TO_SDK);
+        packageManager.removeResolveInfosForIntent(redirectIntent, activity.getPackageName());
+
+        assertThat(ssoDeeplink.isSupported(REDIRECT_TO_SDK)).isFalse();
+
+        verify(appProtocol, never()).isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED);
+        verify(appProtocol, never()).isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED);
+    }
+
+    @Test
+    public void execute_withRidesInstalled_andDefaultFlow_andNoProductPriority_shouldSetPackageAndStartActivityForResult() {
+        enableSupport(DEFAULT);
+
         String packageName = "PACKAGE_NAME";
         PackageInfo packageInfo = new PackageInfo();
         packageInfo.packageName = packageName;
 
-        when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED)).thenReturn(true);
         when(appProtocol.getInstalledPackages(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED))
                 .thenReturn(Collections.singletonList(packageInfo));
 
-        new SsoDeeplink.Builder(activity)
-                .clientId(CLIENT_ID)
-                .scopes(Scope.HISTORY, Scope.PROFILE)
-                .activityRequestCode(REQUEST_CODE)
-                .appProtocol(appProtocol)
-                .build()
-                .execute();
+        ssoDeeplink.execute();
+
+        verify(appProtocol).getInstalledPackages(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED);
+        verify(appProtocol, never()).getInstalledPackages(any(Context.class), eq(UBER_EATS), anyInt());
 
         final ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
         verify(activity).startActivityForResult(intentCaptor.capture(), eq(REQUEST_CODE));
         Intent intent = intentCaptor.getValue();
 
         assertThat(intent.getPackage()).isEqualTo(packageName);
+        assertThat(intent.getData().toString()).isEqualTo(DEFAULT_URI);
     }
 
     @Test
-    public void execute_withoutRegion_shouldUseWorld() {
-        enableSupport();
+    public void execute_withRidesInstalled_andRedirectToSdkFlow_andNoProductPriority_shouldSetPackageAndStartActivity() {
+        enableSupport(REDIRECT_TO_SDK);
+
+        String packageName = "PACKAGE_NAME";
+        PackageInfo packageInfo = new PackageInfo();
+        packageInfo.packageName = packageName;
+
+        when(appProtocol.getInstalledPackages(activity, UBER, MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED))
+                .thenReturn(Collections.singletonList(packageInfo));
+
+        ssoDeeplink.execute(REDIRECT_TO_SDK);
+        verify(appProtocol).getInstalledPackages(activity, UBER, MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED);
+        verify(appProtocol, never()).getInstalledPackages(any(Context.class), eq(UBER_EATS), anyInt());
+
+        final ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
+        verify(activity).startActivity(intentCaptor.capture());
+        Intent intent = intentCaptor.getValue();
+
+        String expectedUri =
+                "uber://connect?client_id=MYCLIENTID&scope=profile%20history&sdk=android&flow_type=REDIRECT_TO_SDK"
+                        + "&redirect_uri=com.example.app%3A%2F%2Fredirect&sdk_version="
+                        + BuildConfig.VERSION_NAME;
+
+        assertThat(intent.getData().toString()).isEqualTo(expectedUri);
+        assertThat(intent.getPackage()).isEqualTo(packageName);
+    }
+
+    @Test
+    public void execute_withEatsProductFlowPriority_shouldLaunchEats() {
+        enableSupport(DEFAULT);
+
+        String eatsPackageName = "com.ubercab.eats";
+        PackageInfo eatsPackageInfo = new PackageInfo();
+        eatsPackageInfo.packageName = eatsPackageName;
+
+        when(appProtocol.getInstalledPackages(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED))
+                .thenReturn(Collections.singletonList(eatsPackageInfo));
 
         new SsoDeeplink.Builder(activity)
                 .clientId(CLIENT_ID)
-                .scopes(Scope.HISTORY, Scope.PROFILE)
                 .activityRequestCode(REQUEST_CODE)
+                .scopes(GENERAL_SCOPES)
                 .appProtocol(appProtocol)
+                .productFlowPriority(ImmutableList.of(UBER_EATS))
                 .build()
                 .execute();
 
-        final ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
-        final ArgumentCaptor<Integer> requestCodeCaptor = ArgumentCaptor.forClass(Integer.class);
-        verify(activity).startActivityForResult(intentCaptor.capture(), requestCodeCaptor.capture());
+        ArgumentCaptor<Intent> intentArgumentCaptor = ArgumentCaptor.forClass(Intent.class);
+        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), anyInt());
 
-        final Uri uri = intentCaptor.getValue().getData();
-
-        assertThat(uri.toString()).isEqualTo(DEFAULT_REGION);
-        assertThat(requestCodeCaptor.getValue()).isEqualTo(REQUEST_CODE);
+        assertThat(intentArgumentCaptor.getValue().getPackage()).isEqualTo(eatsPackageName);
     }
 
     @Test
-    public void execute_withoutRequestCode_shouldUseDefaultRequstCode() {
-        enableSupport();
+    public void execute_withCombinedProductFlowPriority_andBothAppsInstalled_shouldLaunchFirstPriorityApp() {
+        enableSupport(DEFAULT);
+
+        String eatsPackageName = "com.ubercab.eats";
+        PackageInfo eatsPackageInfo = new PackageInfo();
+        eatsPackageInfo.packageName = eatsPackageName;
+
+        String ridesPackageName = "com.ubercab";
+        PackageInfo ridesPackageInfo = new PackageInfo();
+        ridesPackageInfo.packageName = ridesPackageName;
+
+        when(appProtocol.getInstalledPackages(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED))
+                .thenReturn(Collections.singletonList(eatsPackageInfo));
+        when(appProtocol.getInstalledPackages(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED))
+                .thenReturn(Collections.singletonList(ridesPackageInfo));
+
+        new SsoDeeplink.Builder(activity)
+                .clientId(CLIENT_ID)
+                .activityRequestCode(REQUEST_CODE)
+                .scopes(GENERAL_SCOPES)
+                .appProtocol(appProtocol)
+                .productFlowPriority(ImmutableList.of(UBER, UBER_EATS))
+                .build()
+                .execute();
+
+        ArgumentCaptor<Intent> intentArgumentCaptor = ArgumentCaptor.forClass(Intent.class);
+        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), anyInt());
+
+        assertThat(intentArgumentCaptor.getValue().getPackage()).isEqualTo(ridesPackageName);
+    }
+
+    @Test
+    public void execute_withoutRequestCode_shouldUseDefaultRequestCode() {
+        enableSupport(DEFAULT);
 
         new SsoDeeplink.Builder(activity)
                 .clientId(CLIENT_ID)
                 .scopes(GENERAL_SCOPES)
                 .appProtocol(appProtocol)
+                .redirectUri(REDIRECT_URI)
                 .build()
                 .execute();
 
@@ -196,26 +430,13 @@ public class SsoDeeplinkTest extends RobolectricTestBase {
 
         Uri uri = intentCaptor.getValue().getData();
 
-        assertThat(uri.toString()).isEqualTo(DEFAULT_REGION);
+        assertThat(uri.toString()).isEqualTo(DEFAULT_URI);
         assertThat(requestCodeCaptor.getValue()).isEqualTo(LoginManager.REQUEST_CODE_LOGIN_DEFAULT);
-    }
-
-
-    @Test(expected = IllegalStateException.class)
-    public void execute_withoutScopes_shouldFail() {
-        enableSupport();
-
-        new SsoDeeplink.Builder(activity)
-                .clientId(CLIENT_ID)
-                .activityRequestCode(REQUEST_CODE)
-                .appProtocol(appProtocol)
-                .build()
-                .execute();
     }
 
     @Test
     public void execute_withScopesAndCustomScopes_shouldSucceed() {
-        enableSupport();
+        enableSupport(DEFAULT);
 
         Collection<String> collection = Arrays.asList("sample", "test");
 
@@ -236,56 +457,43 @@ public class SsoDeeplinkTest extends RobolectricTestBase {
     }
 
     @Test
-    public void execute_withEatsProductFlowPriority_shouldLaunchEats() {
-        enableSupport();
-        String eatsPackageName = "com.ubercab.eats";
-        PackageInfo eatsPackageInfo = new PackageInfo();
-        eatsPackageInfo.packageName = eatsPackageName;
-        when(appProtocol.getInstalledPackages(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED))
-                .thenReturn(Collections.singletonList(eatsPackageInfo));
+    public void execute_withoutRedirectUri_shouldUseDefaultUri() {
+        enableSupport(REDIRECT_TO_SDK);
+        packageManager.removeResolveInfosForIntent(redirectIntent, activity.getPackageName());
+        String expectedRedirectUri = activity.getPackageName().concat(".uberauth://redirect");
+        Intent expectedIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(expectedRedirectUri));
+        expectedIntent.setPackage(activity.getPackageName());
+        packageManager.addResolveInfoForIntent(expectedIntent, resolveInfo);
 
         new SsoDeeplink.Builder(activity)
                 .clientId(CLIENT_ID)
-                .activityRequestCode(REQUEST_CODE)
                 .scopes(GENERAL_SCOPES)
                 .appProtocol(appProtocol)
-                .productFlowPriority(ImmutableList.of(UBER_EATS))
                 .build()
-                .execute();
+                .execute(REDIRECT_TO_SDK);
 
         ArgumentCaptor<Intent> intentArgumentCaptor = ArgumentCaptor.forClass(Intent.class);
-        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), anyInt());
+        verify(activity).startActivity(intentArgumentCaptor.capture());
 
-        assertThat(intentArgumentCaptor.getValue().getPackage()).isEqualTo(eatsPackageName);
+        Uri uri = intentArgumentCaptor.getValue().getData();
+        assertThat(uri.getQueryParameter("redirect_uri")).isEqualTo(expectedRedirectUri);
     }
 
-    @Test
-    public void execute_withMissingProductFlowPriority_shouldLaunchRides() {
-        enableSupport();
-        String ridesPackageName = "com.ubercab";
-        PackageInfo ridesPackageInfo = new PackageInfo();
-        ridesPackageInfo.packageName = ridesPackageName;
-        when(appProtocol.getInstalledPackages(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED))
-                .thenReturn(Collections.singletonList(ridesPackageInfo));
+    @Test(expected = IllegalStateException.class)
+    public void execute_withoutScopes_shouldFail() {
+        enableSupport(DEFAULT);
 
         new SsoDeeplink.Builder(activity)
                 .clientId(CLIENT_ID)
                 .activityRequestCode(REQUEST_CODE)
-                .scopes(GENERAL_SCOPES)
                 .appProtocol(appProtocol)
-                .productFlowPriority(ImmutableList.<SupportedAppType>of())
                 .build()
                 .execute();
-
-        ArgumentCaptor<Intent> intentArgumentCaptor = ArgumentCaptor.forClass(Intent.class);
-        verify(activity).startActivityForResult(intentArgumentCaptor.capture(), anyInt());
-
-        assertThat(intentArgumentCaptor.getValue().getPackage()).isEqualTo(ridesPackageName);
     }
 
     @Test(expected = NullPointerException.class)
     public void execute_withoutClientId_shouldFail() {
-        enableSupport();
+        enableSupport(DEFAULT);
 
         new SsoDeeplink.Builder(activity)
                 .scopes(GENERAL_SCOPES)
@@ -296,9 +504,8 @@ public class SsoDeeplinkTest extends RobolectricTestBase {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void execute_withoutAppInstalled_shouldFail() {
+    public void execute_withRidesBelowMinVersion_noProductPriority_shouldFail() {
         when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED)).thenReturn(false);
-        when(appProtocol.isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED)).thenReturn(false);
 
         new SsoDeeplink.Builder(activity)
                 .clientId(CLIENT_ID)
@@ -307,8 +514,49 @@ public class SsoDeeplinkTest extends RobolectricTestBase {
                 .execute();
     }
 
-    private void enableSupport() {
-        when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED)).thenReturn(true);
+    @Test(expected = IllegalStateException.class)
+    public void execute_withBothAppsBelowMinVersion_andCombinedProductPriority_shouldFail() {
+        when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_SUPPORTED)).thenReturn(false);
+        when(appProtocol.isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED)).thenReturn(false);
+
+        new SsoDeeplink.Builder(activity)
+                .clientId(CLIENT_ID)
+                .scopes(GENERAL_SCOPES)
+                .productFlowPriority(ImmutableList.of(UBER, UBER_EATS))
+                .build()
+                .execute();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void execute_withBothAppsBelowMinRedirectToSdkVersion_andCombinedProductPriority_shouldFail() {
+        when(appProtocol.isInstalled(activity, UBER, MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED)).thenReturn(false);
+        when(appProtocol.isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED)).thenReturn(false);
+
+        new SsoDeeplink.Builder(activity)
+                .clientId(CLIENT_ID)
+                .scopes(GENERAL_SCOPES)
+                .productFlowPriority(ImmutableList.of(UBER, UBER_EATS))
+                .build()
+                .execute(REDIRECT_TO_SDK);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void execute_withRedirectToSdkFlowVersion_andCantResolveRedirectIntent_shouldFail() {
+        enableSupport(REDIRECT_TO_SDK);
+        packageManager.removeResolveInfosForIntent(redirectIntent, activity.getPackageName());
+
+        new SsoDeeplink.Builder(activity)
+                .clientId(CLIENT_ID)
+                .scopes(GENERAL_SCOPES)
+                .build()
+                .execute(REDIRECT_TO_SDK);
+    }
+
+    private void enableSupport(SsoDeeplink.FlowVersion flowVersion) {
+        int ridesMinVersion = flowVersion == REDIRECT_TO_SDK
+                ? MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED
+                : MIN_UBER_RIDES_VERSION_SUPPORTED;
+        when(appProtocol.isInstalled(activity, UBER, ridesMinVersion)).thenReturn(true);
         when(appProtocol.isInstalled(activity, UBER_EATS, MIN_UBER_EATS_VERSION_SUPPORTED)).thenReturn(true);
     }
 }


### PR DESCRIPTION
Description: Updates `LoginManager` and `LoginActivity` in order to support the new SSO Flow implemented in the mobile apps conforming to [RFC 8252](https://tools.ietf.org/html/rfc8252).

In the new flow `LoginActivity` receives the response from the eater/rider app in `handleResponse` instead of sending it directly to an Activity in the calling application.

Related issue(s): https://github.com/uber/rides-android-sdk/issues/138

Verified to be working in the following scenarios:

| Method | Test Case | Behavior | 
| ------------- | ------------- | --------- |
| `LoginManager.login` | Rides installed (above min RedirectToSdk supported version)  | Successful Login (with redirect to sdk flow) + refresh token |
| `LoginManager.login`  | Rides installed (below RedirectToSdk supported version) | Successful Login (with default flow) + refresh token|
| `LoginManager.login` | Eats installed (above min supported version) | Successful Login (with redirect to sdk flow) + refresh token |
| `LoginManager.login` | No supported apps installed + general scopes | Successful Login with Implicit Grant (no refresh token) |
| `LoginManager.login` | No supported apps installed + privileged scopes | Redirect to Play Store |
| `LoginManager.login` | setAuthCodeFlowEnabled(true) and no supported apps installed | Successful Login with Authorization Code |
| `LoginManager.loginForAuthorizationCode` | N/A | Successful Login with Authorization Code |
| `LoginManager.loginForImplicitGrant` | general scopes | Successful Login with Implicit Grant |
| `LoginManager.loginForImplicitGrant` | privileged scopes | Login failure (INVALID_RESPONSE error) |