### PR TITLE
Fix NPE caused by unset `productFlowPriority`

### DIFF
--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginManager.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginManager.java
@@ -95,7 +95,7 @@ public class LoginManager {
     private final int requestCode;
     private final LegacyUriRedirectHandler legacyUriRedirectHandler;
 
-    private Collection<SupportedAppType> productFlowPriority;
+    private ArrayList<SupportedAppType> productFlowPriority;
     private boolean authCodeFlowEnabled = false;
     @Deprecated
     private boolean redirectForAuthorizationCode = false;
@@ -152,6 +152,7 @@ public class LoginManager {
             @NonNull LegacyUriRedirectHandler legacyUriRedirectHandler) {
         this.accessTokenStorage = accessTokenStorage;
         this.callback = loginCallback;
+        this.productFlowPriority = new ArrayList<>();
         this.sessionConfiguration = configuration;
         this.requestCode = requestCode;
         this.legacyUriRedirectHandler = legacyUriRedirectHandler;
@@ -178,7 +179,7 @@ public class LoginManager {
         if (ssoDeeplink.isSupported(SsoDeeplink.FlowVersion.REDIRECT_TO_SDK)) {
             Intent intent = LoginActivity.newIntent(
                     activity,
-                    new ArrayList<>(productFlowPriority),
+                    productFlowPriority,
                     sessionConfiguration,
                     ResponseType.TOKEN,
                     false,
@@ -372,7 +373,7 @@ public class LoginManager {
      * @return this instance of {@link LoginManager}.
      */
     public LoginManager setProductFlowPriority(@NonNull Collection<SupportedAppType> productFlowPriority) {
-        this.productFlowPriority = productFlowPriority;
+        this.productFlowPriority = new ArrayList<>(productFlowPriority);
         return this;
     }
 

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginManagerTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginManagerTest.java
@@ -36,6 +36,7 @@ import com.uber.sdk.core.auth.AccessTokenStorage;
 import com.uber.sdk.core.auth.Scope;
 import com.uber.sdk.core.client.Session;
 import com.uber.sdk.core.client.SessionConfiguration;
+import edu.emory.mathcs.backport.java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -156,6 +157,27 @@ public class LoginManagerTest extends RobolectricTestBase {
 
         final Intent resultIntent = intentCaptor.getValue();
         validateLoginIntentFields(resultIntent, new ArrayList<SupportedAppType>(productPriority), sessionConfiguration,
+                ResponseType.TOKEN, false, true, true);
+        assertThat(codeCaptor.getValue()).isEqualTo(REQUEST_CODE_LOGIN_DEFAULT);
+    }
+
+    @Test
+    public void login_withoutAppPriority_shouldLoginActivityWithSsoParams() {
+        when(ssoDeeplink.isSupported(REDIRECT_TO_SDK)).thenReturn(true);
+        ArrayList<SupportedAppType> supportedAppTypes = new ArrayList<>();
+        supportedAppTypes.add(UBER);
+
+        loginManager.login(activity);
+
+        verify(ssoDeeplink).isSupported(REDIRECT_TO_SDK);
+
+        ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
+        ArgumentCaptor<Integer> codeCaptor = ArgumentCaptor.forClass(Integer.class);
+
+        verify(activity).startActivityForResult(intentCaptor.capture(), codeCaptor.capture());
+
+        final Intent resultIntent = intentCaptor.getValue();
+        validateLoginIntentFields(resultIntent, supportedAppTypes, sessionConfiguration,
                 ResponseType.TOKEN, false, true, true);
         assertThat(codeCaptor.getValue()).isEqualTo(REQUEST_CODE_LOGIN_DEFAULT);
     }
@@ -493,7 +515,7 @@ public class LoginManagerTest extends RobolectricTestBase {
 
     private void validateLoginIntentFields(
             @NonNull Intent loginIntent,
-            @NonNull ArrayList<SupportedAppType> expectedProductPriority,
+            @NonNull Iterable<SupportedAppType> expectedProductPriority,
             @NonNull SessionConfiguration expectedSessionConfiguration,
             @NonNull ResponseType expectedResponseType,
             boolean expectedForceWebview,

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginManagerTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginManagerTest.java
@@ -156,7 +156,7 @@ public class LoginManagerTest extends RobolectricTestBase {
         verify(activity).startActivityForResult(intentCaptor.capture(), codeCaptor.capture());
 
         final Intent resultIntent = intentCaptor.getValue();
-        validateLoginIntentFields(resultIntent, new ArrayList<SupportedAppType>(productPriority), sessionConfiguration,
+        validateLoginIntentFields(resultIntent, new ArrayList<>(productPriority), sessionConfiguration,
                 ResponseType.TOKEN, false, true, true);
         assertThat(codeCaptor.getValue()).isEqualTo(REQUEST_CODE_LOGIN_DEFAULT);
     }
@@ -164,8 +164,6 @@ public class LoginManagerTest extends RobolectricTestBase {
     @Test
     public void login_withoutAppPriority_shouldLoginActivityWithSsoParams() {
         when(ssoDeeplink.isSupported(REDIRECT_TO_SDK)).thenReturn(true);
-        ArrayList<SupportedAppType> supportedAppTypes = new ArrayList<>();
-        supportedAppTypes.add(UBER);
 
         loginManager.login(activity);
 
@@ -177,7 +175,7 @@ public class LoginManagerTest extends RobolectricTestBase {
         verify(activity).startActivityForResult(intentCaptor.capture(), codeCaptor.capture());
 
         final Intent resultIntent = intentCaptor.getValue();
-        validateLoginIntentFields(resultIntent, supportedAppTypes, sessionConfiguration,
+        validateLoginIntentFields(resultIntent, new ArrayList<SupportedAppType>(), sessionConfiguration,
                 ResponseType.TOKEN, false, true, true);
         assertThat(codeCaptor.getValue()).isEqualTo(REQUEST_CODE_LOGIN_DEFAULT);
     }
@@ -515,7 +513,7 @@ public class LoginManagerTest extends RobolectricTestBase {
 
     private void validateLoginIntentFields(
             @NonNull Intent loginIntent,
-            @NonNull Iterable<SupportedAppType> expectedProductPriority,
+            @NonNull List<SupportedAppType> expectedProductPriority,
             @NonNull SessionConfiguration expectedSessionConfiguration,
             @NonNull ResponseType expectedResponseType,
             boolean expectedForceWebview,
@@ -524,7 +522,7 @@ public class LoginManagerTest extends RobolectricTestBase {
         assertThat(loginIntent.getSerializableExtra(EXTRA_SESSION_CONFIGURATION)).isEqualTo(expectedSessionConfiguration);
         assertThat(loginIntent.getSerializableExtra(EXTRA_RESPONSE_TYPE)).isEqualTo(expectedResponseType);
         assertThat((ArrayList<SupportedAppType>) loginIntent.getSerializableExtra(EXTRA_PRODUCT_PRIORITY))
-                .hasSameElementsAs(expectedProductPriority);
+                .containsAll(expectedProductPriority);
         assertThat(loginIntent.getBooleanExtra(EXTRA_FORCE_WEBVIEW, false)).isEqualTo(expectedForceWebview);
         assertThat(loginIntent.getBooleanExtra(EXTRA_SSO_ENABLED, false)).isEqualTo(expectedSsoEnabled);
         assertThat(loginIntent.getBooleanExtra(EXTRA_REDIRECT_TO_PLAY_STORE_ENABLED, false))


### PR DESCRIPTION
Fixed #153
Verified by unit tests.

Description:  Lack of an initial value caused a NPE when `LoginManager#login(Activity)` was invoked.

Related issue(s):  #153