### PR TITLE
Update minimum Uber Eats version to 2488

### DIFF
--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/SsoDeeplink.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/SsoDeeplink.java
@@ -59,7 +59,7 @@ public class SsoDeeplink implements Deeplink {
     @VisibleForTesting
     static final int MIN_UBER_RIDES_VERSION_SUPPORTED = 31302;
     @VisibleForTesting
-    static final int MIN_UBER_EATS_VERSION_SUPPORTED = 1085;
+    static final int MIN_UBER_EATS_VERSION_SUPPORTED = 2488;
 
     @VisibleForTesting
     static final int MIN_UBER_RIDES_VERSION_REDIRECT_FLOW_SUPPORTED = 35757;


### PR DESCRIPTION
Description: Bumps the minimum Uber Eats version compatible with SSO authentication. This Uber Eats version has fixes for authenticating fresh installs and logged out users.

Related issue(s):