### PR TITLE
Introduce compatibility with nightly build

### DIFF
--- a/core-android/src/main/java/com/uber/sdk/android/core/utils/AppProtocol.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/utils/AppProtocol.java
@@ -38,11 +38,8 @@ public class AppProtocol {
             {"com.ubercab.eats.debug", "com.ubercab.eats.exo", "com.ubercab.eats.nightly", "com.ubercab.eats"};
     public static final String PLATFORM = "android";
 
-    // Both com.ubercab.eats and com.ubercab.eats.nightly share the same hash
-    private static final String UBER_EATS_HASH = "ae0b86995f174533b423067837beba13d922fbb0";
-    // For com.ubercab.eats.internal
-    private static final String UBER_EATS_INTERNAL_HASH = "9a715f0cbb44b01e3c41c9bda30feba107561e79";
     private static final String UBER_RIDER_HASH = "411c40b31f6d01dac68d711df99b6eafeec8e73b";
+    private static final String UBER_EATS_HASH = "ae0b86995f174533b423067837beba13d922fbb0";
     private static final String HASH_ALGORITHM_SHA1 = "SHA-1";
     private static final int DEFAULT_MIN_VERSION = 0;
 
@@ -53,7 +50,6 @@ public class AppProtocol {
         HashSet<String> set = new HashSet<>();
         set.add(UBER_RIDER_HASH);
         set.add(UBER_EATS_HASH);
-        set.add(UBER_EATS_INTERNAL_HASH);
         return set;
     }
 

--- a/core-android/src/main/java/com/uber/sdk/android/core/utils/AppProtocol.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/utils/AppProtocol.java
@@ -26,20 +26,19 @@ import static com.uber.sdk.android.core.SupportedAppType.UBER;
 import static com.uber.sdk.android.core.SupportedAppType.UBER_EATS;
 
 public class AppProtocol {
-    @Deprecated
-    public static final String[] UBER_PACKAGE_NAMES =
-            {"com.ubercab", "com.ubercab.presidio.app", "com.ubercab.presidio.exo", "com.ubercab.presidio.development"};
-
     @VisibleForTesting
     static final String[] RIDER_PACKAGE_NAMES =
             {"com.ubercab.presidio.development", "com.ubercab.presidio.exo", "com.ubercab.presidio.app", "com.ubercab"};
     @VisibleForTesting
     static final String[] EATS_PACKAGE_NAMES =
-            {"com.ubercab.eats.debug", "com.ubercab.eats.exo", "com.ubercab.eats"};
+            {"com.ubercab.eats.debug", "com.ubercab.eats.exo", "com.ubercab.eats", "com.ubercab.eats.internal", "com.ubercab.eats.nightly"};
     public static final String PLATFORM = "android";
 
-    private static final String UBER_RIDER_HASH = "411c40b31f6d01dac68d711df99b6eafeec8e73b";
+    // Both com.ubercab.eats and com.ubercab.eats.nightly share the same hash
     private static final String UBER_EATS_HASH = "ae0b86995f174533b423067837beba13d922fbb0";
+    // For com.ubercab.eats.internal
+    private static final String UBER_EATS_INTERNAL_HASH = "9a715f0cbb44b01e3c41c9bda30feba107561e79";
+    private static final String UBER_RIDER_HASH = "411c40b31f6d01dac68d711df99b6eafeec8e73b";
     private static final String HASH_ALGORITHM_SHA1 = "SHA-1";
     private static final int DEFAULT_MIN_VERSION = 0;
 
@@ -50,6 +49,7 @@ public class AppProtocol {
         HashSet<String> set = new HashSet<>();
         set.add(UBER_RIDER_HASH);
         set.add(UBER_EATS_HASH);
+        set.add(UBER_EATS_INTERNAL_HASH);
         return set;
     }
 

--- a/core-android/src/main/java/com/uber/sdk/android/core/utils/AppProtocol.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/utils/AppProtocol.java
@@ -26,12 +26,16 @@ import static com.uber.sdk.android.core.SupportedAppType.UBER;
 import static com.uber.sdk.android.core.SupportedAppType.UBER_EATS;
 
 public class AppProtocol {
+    @Deprecated
+    public static final String[] UBER_PACKAGE_NAMES =
+            {"com.ubercab", "com.ubercab.presidio.app", "com.ubercab.presidio.exo", "com.ubercab.presidio.development"};
+
     @VisibleForTesting
     static final String[] RIDER_PACKAGE_NAMES =
             {"com.ubercab.presidio.development", "com.ubercab.presidio.exo", "com.ubercab.presidio.app", "com.ubercab"};
     @VisibleForTesting
     static final String[] EATS_PACKAGE_NAMES =
-            {"com.ubercab.eats.debug", "com.ubercab.eats.exo", "com.ubercab.eats", "com.ubercab.eats.internal", "com.ubercab.eats.nightly"};
+            {"com.ubercab.eats.debug", "com.ubercab.eats.exo", "com.ubercab.eats.internal", "com.ubercab.eats.nightly", "com.ubercab.eats"};
     public static final String PLATFORM = "android";
 
     // Both com.ubercab.eats and com.ubercab.eats.nightly share the same hash

--- a/core-android/src/main/java/com/uber/sdk/android/core/utils/AppProtocol.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/utils/AppProtocol.java
@@ -35,7 +35,7 @@ public class AppProtocol {
             {"com.ubercab.presidio.development", "com.ubercab.presidio.exo", "com.ubercab.presidio.app", "com.ubercab"};
     @VisibleForTesting
     static final String[] EATS_PACKAGE_NAMES =
-            {"com.ubercab.eats.debug", "com.ubercab.eats.exo", "com.ubercab.eats.internal", "com.ubercab.eats.nightly", "com.ubercab.eats"};
+            {"com.ubercab.eats.debug", "com.ubercab.eats.exo", "com.ubercab.eats.nightly", "com.ubercab.eats"};
     public static final String PLATFORM = "android";
 
     // Both com.ubercab.eats and com.ubercab.eats.nightly share the same hash


### PR DESCRIPTION
Description: In the SSO flow, the SDK looks for compatible application packages on the device. Today, it looks for the production & debug packages. This adds support for the nightly package as well.

This is useful as we can distribute nightly packages to partners to verify fixes.

Related issue(s): Addresses #164