### PR TITLE
fix crash in CustomTabsHelper if connection is null

### DIFF
--- a/core-android/src/main/java/com/uber/sdk/android/core/utils/CustomTabsHelper.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/utils/CustomTabsHelper.java
@@ -97,8 +97,10 @@ public class CustomTabsHelper {
      * Called to clean up the CustomTab when the parentActivity is destroyed.
      */
     public void onDestroy(Activity parentActivity) {
-        parentActivity.unbindService(connection);
-        connection = null;
+        if (connection != null) {
+            parentActivity.unbindService(connection);
+            connection = null;
+        }
     }
 
     /**


### PR DESCRIPTION
Description:
There are some codepaths which could lead to connection being null and when a call is made to `CustomTabsHelper#onDestroy()` it could lead to a `java.lang.IllegalArgumentException`

Related issue(s):
https://github.com/uber/rides-android-sdk/issues/179