### PR TITLE
Fixing Tests Associated With AndroidX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine, required for emulator testing
     strategy:
       matrix:
-        api-level: [ 21, 23, 26, 29, 30 ]
+        api-level: [ 21, 23, 26 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine, required for emulator testing
     strategy:
       matrix:
-        api-level: [ 29, 30 ]
+        api-level: [ 21, 23, 26, 29, 30 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine, required for emulator testing
     strategy:
       matrix:
-        api-level: [ 21, 23, 26, 29, 30 ]
+        api-level: [ 29, 30 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/core-android/src/test/java/com/uber/sdk/android/core/RobolectricTestBase.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/RobolectricTestBase.java
@@ -30,7 +30,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 21)
+@Config(sdk = 21)
 public abstract class RobolectricTestBase {
 
     @Rule

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/LegacyUriRedirectHandlerTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/LegacyUriRedirectHandlerTest.java
@@ -216,7 +216,7 @@ public class LegacyUriRedirectHandlerTest extends RobolectricTestBase {
 
     private void assertNoLogs() {
         List<ShadowLog.LogItem> logItemList = ShadowLog.getLogsForTag(UberSdk.UBER_SDK_LOG_TAG);
-        assertThat(ShadowLog.getLogsForTag(UberSdk.UBER_SDK_LOG_TAG)).isNull();
+        assertThat(ShadowLog.getLogsForTag(UberSdk.UBER_SDK_LOG_TAG)).isEmpty();
     }
 
     private void assertDialogShown() {

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginActivityTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginActivityTest.java
@@ -41,9 +41,9 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowWebView;
-import org.robolectric.util.ActivityController;
 
 import java.util.ArrayList;
 import java.util.Set;
@@ -91,7 +91,7 @@ public class LoginActivityTest extends RobolectricTestBase {
                 .build();
 
         Intent data = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration, ResponseType.TOKEN);
-        loginActivity = Robolectric.buildActivity(LoginActivity.class).withIntent(data).get();
+        loginActivity = Robolectric.buildActivity(LoginActivity.class, data).get();
 
         when(ssoDeeplinkFactory.getSsoDeeplink(any(LoginActivity.class),
                 eq(productPriority), any(SessionConfiguration.class))).thenReturn(ssoDeeplink);
@@ -116,8 +116,7 @@ public class LoginActivityTest extends RobolectricTestBase {
         Intent intent = new Intent();
         intent.putExtra(LoginActivity.EXTRA_SESSION_CONFIGURATION, new SessionConfiguration.Builder().setClientId(CLIENT_ID).build());
 
-        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class)
-                .withIntent(intent)
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class, intent)
                 .create();
 
         ShadowActivity shadowActivity = shadowOf(controller.get());
@@ -136,7 +135,7 @@ public class LoginActivityTest extends RobolectricTestBase {
         intent.putExtra(LoginActivity.EXTRA_RESPONSE_TYPE, (ResponseType) null);
 
         ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class)
-                .withIntent(intent)
+                .newIntent(intent)
                 .create();
 
         ShadowActivity shadowActivity = shadowOf(controller.get());
@@ -153,7 +152,7 @@ public class LoginActivityTest extends RobolectricTestBase {
         Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), productPriority,
                 loginConfiguration, ResponseType.TOKEN, false, true, true);
 
-        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).withIntent(intent);
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class, intent);
         loginActivity = controller.get();
         loginActivity.ssoDeeplinkFactory = ssoDeeplinkFactory;
 
@@ -169,7 +168,7 @@ public class LoginActivityTest extends RobolectricTestBase {
         Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), productPriority,
                 loginConfiguration, ResponseType.TOKEN, false, true, true);
 
-        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).withIntent(intent);
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).newIntent(intent);
         loginActivity = controller.get();
         loginActivity.ssoDeeplinkFactory = ssoDeeplinkFactory;
         ShadowActivity shadowActivity = shadowOf(loginActivity);
@@ -189,7 +188,7 @@ public class LoginActivityTest extends RobolectricTestBase {
         Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
                 ResponseType.CODE, true);
 
-        loginActivity = Robolectric.buildActivity(LoginActivity.class).withIntent(intent).create().get();
+        loginActivity = Robolectric.buildActivity(LoginActivity.class, intent).create().get();
         ShadowWebView webview = Shadows.shadowOf(loginActivity.webView);
 
         String expectedUrl = AuthUtils.buildUrl(REDIRECT_URI, ResponseType.CODE, loginConfiguration);
@@ -201,7 +200,7 @@ public class LoginActivityTest extends RobolectricTestBase {
         Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
                 ResponseType.CODE, false);
 
-        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).withIntent(intent);
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class, intent);
         loginActivity = controller.get();
         loginActivity.customTabsHelper = customTabsHelper;
         controller.create();
@@ -216,7 +215,7 @@ public class LoginActivityTest extends RobolectricTestBase {
         Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
                 ResponseType.TOKEN, true);
 
-        loginActivity = Robolectric.buildActivity(LoginActivity.class).withIntent(intent).create().get();
+        loginActivity = Robolectric.buildActivity(LoginActivity.class, intent).create().get();
         ShadowWebView webview = Shadows.shadowOf(loginActivity.webView);
 
         String expectedUrl = AuthUtils.buildUrl(REDIRECT_URI, ResponseType.TOKEN, loginConfiguration);
@@ -228,7 +227,7 @@ public class LoginActivityTest extends RobolectricTestBase {
         Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
                 ResponseType.TOKEN, false);
 
-        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).withIntent(intent);
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).newIntent(intent);
         loginActivity = controller.get();
         loginActivity.customTabsHelper = customTabsHelper;
         controller.create();
@@ -248,7 +247,7 @@ public class LoginActivityTest extends RobolectricTestBase {
         Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
                 ResponseType.TOKEN, true);
 
-        loginActivity = Robolectric.buildActivity(LoginActivity.class).withIntent(intent).create().get();
+        loginActivity = Robolectric.buildActivity(LoginActivity.class, intent).create().get();
         ShadowWebView webview = Shadows.shadowOf(loginActivity.webView);
 
         String expectedUrl = AuthUtils.buildUrl(REDIRECT_URI, ResponseType.TOKEN, loginConfiguration);
@@ -265,7 +264,7 @@ public class LoginActivityTest extends RobolectricTestBase {
         Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class), loginConfiguration,
                 ResponseType.TOKEN, false);
 
-        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class).withIntent(intent);
+        ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class, intent);
         loginActivity = controller.get();
         loginActivity.customTabsHelper = customTabsHelper;
         controller.create();
@@ -285,7 +284,7 @@ public class LoginActivityTest extends RobolectricTestBase {
         Intent intent = LoginActivity.newIntent(Robolectric.setupActivity(Activity.class),
                 new ArrayList<SupportedAppType>(), loginConfiguration, ResponseType.TOKEN, true, false, true);
 
-        ShadowActivity shadowActivity = shadowOf(Robolectric.buildActivity(LoginActivity.class).withIntent(intent).create().get());
+        ShadowActivity shadowActivity = shadowOf(Robolectric.buildActivity(LoginActivity.class, intent).create().get());
 
         final Intent signupDeeplinkIntent = shadowActivity.peekNextStartedActivity();
         assertThat(signupDeeplinkIntent.getData().toString()).isEqualTo(SIGNUP_DEEPLINK_URL);

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/OAuthWebViewClientTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/OAuthWebViewClientTest.java
@@ -36,8 +36,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowActivity;
-import org.robolectric.util.ActivityController;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -73,7 +73,7 @@ public class OAuthWebViewClientTest extends RobolectricTestBase {
         Intent intent = new Intent();
         intent.putExtra(LoginActivity.EXTRA_SESSION_CONFIGURATION, config);
         final ActivityController<LoginActivity> controller = Robolectric.buildActivity(LoginActivity.class)
-                .withIntent(intent);
+                .newIntent(intent);
         final ShadowActivity shadowActivity = Shadows.shadowOf(controller.get());
 
         controller.create();

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/SsoDeeplinkTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/SsoDeeplinkTest.java
@@ -41,7 +41,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.res.builder.RobolectricPackageManager;
+import org.robolectric.shadows.ShadowPackageManager;
 import org.robolectric.shadows.ShadowResolveInfo;
 
 import java.util.Arrays;
@@ -65,6 +65,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.robolectric.Shadows.shadowOf;
 
 public class SsoDeeplinkTest extends RobolectricTestBase {
 
@@ -82,7 +83,7 @@ public class SsoDeeplinkTest extends RobolectricTestBase {
 
     Activity activity;
 
-    RobolectricPackageManager packageManager;
+    protected ShadowPackageManager packageManager;
 
     ResolveInfo resolveInfo;
 
@@ -97,7 +98,7 @@ public class SsoDeeplinkTest extends RobolectricTestBase {
         redirectIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(REDIRECT_URI));
         redirectIntent.setPackage(activity.getPackageName());
         resolveInfo = ShadowResolveInfo.newResolveInfo("", activity.getPackageName());
-        packageManager = RuntimeEnvironment.getRobolectricPackageManager();
+        packageManager = shadowOf(RuntimeEnvironment.application.getPackageManager());
         packageManager.addResolveInfoForIntent(redirectIntent, resolveInfo);
 
         ssoDeeplink = new SsoDeeplink.Builder(activity)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -47,14 +47,14 @@ def misc = [
 def support = [
         annotations: "androidx.annotation:annotation:${versions.androidxVersion}",
         appCompat  : "androidx.appcompat:appcompat:${versions.androidxVersion}",
-        chrometabs : "androidx.browser:browser:${versions.androidxVersion}",
+        chrometabs : "androidx.browser:browser:${versions.androidxVersion}"
 ]
 
 def test = [
         androidRunner: "com.android.support.test:runner:${versions.androidTest}",
         androidRules: "com.android.support.test:rules:${versions.androidTest}",
         junit: 'junit:junit:4.12',
-        robolectric: 'org.robolectric:robolectric:3.2.2',
+        robolectric: 'org.robolectric:robolectric:4.0',
         assertj: 'org.assertj:assertj-core:1.7.1',
         mockito: 'org.mockito:mockito-core:1.10.19',
         guava: 'com.google.guava:guava:23.4-android',

--- a/rides-android/src/main/java/com/uber/sdk/android/rides/RideRequestActivity.java
+++ b/rides-android/src/main/java/com/uber/sdk/android/rides/RideRequestActivity.java
@@ -30,6 +30,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;

--- a/rides-android/src/test/java/com/uber/sdk/android/rides/RideRequestActivityTest.java
+++ b/rides-android/src/test/java/com/uber/sdk/android/rides/RideRequestActivityTest.java
@@ -62,7 +62,8 @@ public class RideRequestActivityTest extends RobolectricTestBase {
         Intent data = RideRequestActivity.newIntent(Robolectric.setupActivity(Activity.class), null,
                 new SessionConfiguration.Builder().setClientId("clientId").build(),
                 null);
-        activity = Robolectric.buildActivity(RideRequestActivity.class).withIntent(data).create()
+        activity = Robolectric.buildActivity(RideRequestActivity.class, data)
+                .create()
                 .get();
     }
 
@@ -115,7 +116,7 @@ public class RideRequestActivityTest extends RobolectricTestBase {
                 rideParameters,
                 new SessionConfiguration.Builder().setClientId("clientId").build(),
                 null);
-        activity = Robolectric.buildActivity(RideRequestActivity.class).withIntent(data).create().get();
+        activity = Robolectric.buildActivity(RideRequestActivity.class, data).create().get();
 
         String tokenString = "accessToken1234";
         AccessToken accessToken = new AccessToken(2592000, ImmutableList.of(Scope.RIDE_WIDGETS), tokenString,
@@ -135,7 +136,7 @@ public class RideRequestActivityTest extends RobolectricTestBase {
                 rideParameters,
                 new SessionConfiguration.Builder().setClientId("clientId").build(),
                 null);
-        activity = Robolectric.buildActivity(RideRequestActivity.class).withIntent(data).create().get();
+        activity = Robolectric.buildActivity(RideRequestActivity.class, data).create().get();
         assertEquals(userAgent, activity.rideRequestView.rideParameters.getUserAgent());
     }
 
@@ -144,7 +145,7 @@ public class RideRequestActivityTest extends RobolectricTestBase {
         ShadowActivity shadowActivity = shadowOf(activity);
         Intent intent = new Intent();
         intent.putExtra(RideRequestActivity.EXTRA_LOGIN_CONFIGURATION, new SessionConfiguration.Builder().setClientId("clientId").build());
-        activity = Robolectric.buildActivity(RideRequestActivity.class).withIntent(intent).create().get();
+        activity = Robolectric.buildActivity(RideRequestActivity.class, intent).create().get();
         assertNull(shadowActivity.getResultIntent());
         assertFalse(shadowActivity.isFinishing());
     }

--- a/rides-android/src/test/java/com/uber/sdk/android/rides/RobolectricTestBase.java
+++ b/rides-android/src/test/java/com/uber/sdk/android/rides/RobolectricTestBase.java
@@ -30,6 +30,6 @@ import org.robolectric.annotation.Config;
  * Base test class to remove use of annotations on all test classes.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 21)
+@Config(sdk = 21)
 public abstract class RobolectricTestBase {
 }


### PR DESCRIPTION
Description: Merging in https://github.com/uber/rides-android-sdk/pull/184 caused some tests to break. This was caused by a runtime issue that could not find the resources for instrumented tests. For some reason this worked on Android Studio.

Regardless, the fix is to bump the version of RoboElectric so that it can instrument and find the resources. 

There is also a secondary issue that is caused by the migration to the new android emulator runner. See the linked issue below. I have removed the 29 and 30 api for this reason (even though we only target 28).