### PR TITLE
Added failsafe null check when removing progress indicator

### DIFF
--- a/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginActivity.java
+++ b/core-android/src/main/java/com/uber/sdk/android/core/auth/LoginActivity.java
@@ -471,8 +471,10 @@ public class LoginActivity extends Activity {
     /**
      * Removes progress spinner from the activity
      */
-    @VisibleForTesting void removeProgressIndicator() {
-        if (progressBarLayoutContainer.getParent() != null) {
+    @VisibleForTesting
+    void removeProgressIndicator() {
+        if (progressBarLayoutContainer != null &&
+                progressBarLayoutContainer.getParent() != null) {
             ((ViewGroup) progressBarLayoutContainer.getParent()).removeView(progressBarLayoutContainer);
             progressBarLayoutContainer = null;
         }

--- a/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginActivityTest.java
+++ b/core-android/src/test/java/com/uber/sdk/android/core/auth/LoginActivityTest.java
@@ -435,6 +435,13 @@ public class LoginActivityTest extends RobolectricTestBase {
         assertThat(loginActivity.progressBarLayoutContainer).isNull();
     }
 
+    @Test
+    public void removeProgressIndicator_whenProgressIndicatorIsNotAdded_shouldDoNothing() {
+        // calling removeProgressIndicator should not throw exception
+        loginActivity.removeProgressIndicator();
+        assertThat(loginActivity.progressBarLayoutContainer).isNull();
+    }
+
     private AuthenticationError getErrorFromIntent(Intent intent) {
         return AuthenticationError.fromString(intent.getStringExtra(LoginManager.EXTRA_ERROR));
     }


### PR DESCRIPTION
Description: Closes #204 
In edge cases where we received a replayed response from the server for PAR then we would end up calling remove progress indicator twice when it is already null thereby crashing the application.
Added a null check guard before getting the parent of progressIndicator.

Related issue(s):