### PR TITLE
Adding parcelize

### DIFF
--- a/authentication/build.gradle.kts
+++ b/authentication/build.gradle.kts
@@ -36,6 +36,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.parcelize)
   alias(libs.plugins.spotless)
 }
 
@@ -60,9 +61,9 @@ android {
 }
 
 dependencies {
-  implementation(libs.core.ktx)
   implementation(libs.appCompat)
   implementation(libs.material)
+  implementation(project(":core"))
   testImplementation(libs.junit.junit)
   androidTestImplementation(libs.androidx.test.ext.junit)
   androidTestImplementation(libs.androidx.test.espresso.espresso.core)

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/AuthContext.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/AuthContext.kt
@@ -15,6 +15,9 @@
  */
 package com.uber.sdk2.auth.api.request
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * Represents the context of the authentication request needed for Uber to authenticate the user.
  *
@@ -23,9 +26,9 @@ package com.uber.sdk2.auth.api.request
  * @param prefillInfo The prefill information to be used for the authentication.
  * @param scopes The scopes to request for the authentication.
  */
+@Parcelize
 data class AuthContext(
   val authDestination: AuthDestination,
   val authType: AuthType,
   val prefillInfo: PrefillInfo?,
-  val scopes: String?,
-)
+) : Parcelable

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/AuthDestination.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/AuthDestination.kt
@@ -15,8 +15,12 @@
  */
 package com.uber.sdk2.auth.api.request
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /** Represents the destination app to authenticate the user. */
-sealed class AuthDestination {
+@Parcelize
+sealed class AuthDestination : Parcelable {
   /**
    * Authenticating within the same app by using a system webview, a.k.a Custom Tabs. If custom tabs
    * are unavailable the authentication flow will be launched in the system browser app.
@@ -25,7 +29,8 @@ sealed class AuthDestination {
 
   /**
    * Authenticating via one of the family of Uber apps using the Single Sign-On (SSO) flow in the
-   * order of priority mentioned.
+   * order of priority mentioned. If none of the apps are available we will fall back to the [InApp]
+   * flow
    *
    * @param appPriority The order of the apps to use for the SSO flow.
    */

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/AuthType.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/AuthType.kt
@@ -15,15 +15,19 @@
  */
 package com.uber.sdk2.auth.api.request
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * Represents the type of authentication to perform.
  *
  * @see AuthContext
  */
-sealed class AuthType {
+@Parcelize
+sealed class AuthType(val grantType: String) : Parcelable {
   /** The authorization code flow. */
-  data object AuthCode : AuthType()
+  data object AuthCode : AuthType("code")
 
   /** The proof key for code exchange (PKCE) flow. This is the recommended flow for mobile apps. */
-  data object PKCE : AuthType()
+  data object PKCE : AuthType("code")
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/CrossApp.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/CrossApp.kt
@@ -26,14 +26,22 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 sealed class CrossApp(val packages: List<String>) : Parcelable {
   /** The Eats app. */
-  data object Eats :
-    CrossApp(listOf("com.ubercab.eats", "com.ubercab.eats.exo", "com.ubercab.eats.internal"))
+  data object Eats : CrossApp(EATS_APPS)
 
   /** The Rider app. */
-  data object Rider :
-    CrossApp(listOf("com.ubercab", "com.ubercab.presidio.exo", "com.ubercab.rider.internal"))
+  data object Rider : CrossApp(RIDER_APPS)
 
   /** The Driver app. */
-  data object Driver :
-    CrossApp(listOf("com.ubercab.driver", "com.ubercab.driver.exo", "com.ubercab.driver.internal"))
+  data object Driver : CrossApp(DRIVER_APPS)
+
+  companion object {
+    /** The list of all driver apps. */
+    private val DRIVER_APPS = listOf("com.ubercab.driver", "com.ubercab.driver.exo", "com.ubercab.driver.internal")
+
+    /** The list of all rider apps. */
+    private val RIDER_APPS = listOf("com.ubercab", "com.ubercab.presidio.exo", "com.ubercab.rider.internal")
+
+    /** The list of all Eats apps. */
+    private val EATS_APPS = listOf("com.ubercab.eats", "com.ubercab.eats.exo", "com.ubercab.eats.internal")
+  }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/CrossApp.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/CrossApp.kt
@@ -36,12 +36,15 @@ sealed class CrossApp(val packages: List<String>) : Parcelable {
 
   companion object {
     /** The list of all driver apps. */
-    private val DRIVER_APPS = listOf("com.ubercab.driver", "com.ubercab.driver.exo", "com.ubercab.driver.internal")
+    private val DRIVER_APPS =
+      listOf("com.ubercab.driver", "com.ubercab.driver.exo", "com.ubercab.driver.internal")
 
     /** The list of all rider apps. */
-    private val RIDER_APPS = listOf("com.ubercab", "com.ubercab.presidio.exo", "com.ubercab.rider.internal")
+    private val RIDER_APPS =
+      listOf("com.ubercab", "com.ubercab.presidio.exo", "com.ubercab.rider.internal")
 
     /** The list of all Eats apps. */
-    private val EATS_APPS = listOf("com.ubercab.eats", "com.ubercab.eats.exo", "com.ubercab.eats.internal")
+    private val EATS_APPS =
+      listOf("com.ubercab.eats", "com.ubercab.eats.exo", "com.ubercab.eats.internal")
   }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/CrossApp.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/CrossApp.kt
@@ -15,14 +15,25 @@
  */
 package com.uber.sdk2.auth.api.request
 
-/** Provides different apps that could be used for authentication using SSO flow. */
-sealed class CrossApp {
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Provides different apps that could be used for authentication using SSO flow.
+ *
+ * @param packages The list of packages that could be used for authentication.
+ */
+@Parcelize
+sealed class CrossApp(val packages: List<String>) : Parcelable {
   /** The Eats app. */
-  data object Eats : CrossApp()
+  data object Eats :
+    CrossApp(listOf("com.ubercab.eats", "com.ubercab.eats.exo", "com.ubercab.eats.internal"))
 
   /** The Rider app. */
-  data object Rider : CrossApp()
+  data object Rider :
+    CrossApp(listOf("com.ubercab", "com.ubercab.presidio.exo", "com.ubercab.rider.internal"))
 
   /** The Driver app. */
-  data object Driver : CrossApp()
+  data object Driver :
+    CrossApp(listOf("com.ubercab.driver", "com.ubercab.driver.exo", "com.ubercab.driver.internal"))
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/PrefillInfo.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/PrefillInfo.kt
@@ -15,6 +15,9 @@
  */
 package com.uber.sdk2.auth.api.request
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * Provides a way to prefill the user's information in the authentication flow.
  *
@@ -23,9 +26,10 @@ package com.uber.sdk2.auth.api.request
  * @param lastName The last name to prefill.
  * @param phoneNumber The phone number to prefill.
  */
+@Parcelize
 data class PrefillInfo(
   val email: String,
   val firstName: String,
   val lastName: String,
   val phoneNumber: String,
-)
+) : Parcelable

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
   alias(libs.plugins.android.application) apply false
   alias(libs.plugins.android.library) apply false
   alias(libs.plugins.mavenPublish) apply false
+  alias(libs.plugins.kotlin.parcelize) apply false
   alias(libs.plugins.dokka)
   alias(libs.plugins.spotless)
 }

--- a/core/src/main/kotlin/com/uber/sdk2/core/utils/CustomTabsHelper.kt
+++ b/core/src/main/kotlin/com/uber/sdk2/core/utils/CustomTabsHelper.kt
@@ -121,8 +121,7 @@ object CustomTabsHelper {
           defaultViewHandlerPackageName
         packagesSupportingCustomTabs.contains(STABLE_PACKAGE) -> STABLE_PACKAGE
         packagesSupportingCustomTabs.contains(BETA_PACKAGE) -> BETA_PACKAGE
-        packagesSupportingCustomTabs.contains(DEV_PACKAGE) -> DEV_PACKAGE
-        packagesSupportingCustomTabs.contains(LOCAL_PACKAGE) -> LOCAL_PACKAGE
+        else -> packagesSupportingCustomTabs[0]
       }
     return packageNameToUse
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 
 [libraries]
 jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,6 +41,8 @@ dependencyResolutionManagement {
 rootProject.name = "uber-android-sdk"
 
 include(
+  ":authentication",
+  ":core",
   ":core-android",
   ":rides-android",
   ":samples:request-button-sample",


### PR DESCRIPTION
Description:
Added support for parcelable in the authentication module. The auth request and config objects need to be parcelable to enable launching the AuthActivity with the relevant AuthContext object.
This diff 
- Makes AuthContext, AuthDestination, AuthType, CrossApp and PrefillInfo parcelable
- Fixed a couple of bugs in CustomTabsHelper