### PR TITLE
Added abstractions for AppDiscovery and AuthProvider

### DIFF
--- a/authentication/build.gradle.kts
+++ b/authentication/build.gradle.kts
@@ -62,6 +62,7 @@ android {
 
 dependencies {
   implementation(libs.appCompat)
+  implementation(libs.chrometabs)
   implementation(libs.material)
   implementation(libs.retrofit)
   implementation(libs.retrofit.moshi)

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/AppDiscovering.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/AppDiscovering.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.sdk2.auth.api
+
+import android.net.Uri
+
+/** Provides a way to discover the app to authenticate the user. */
+interface AppDiscovering {
+
+  /**
+   * Finds the best application to handle a given [Uri].
+   *
+   * This function searches through available applications on the device to determine the most
+   * suitable app that can handle the specified [Uri].
+   *
+   * @param uri The [Uri] for which the best application needs to be found. The [Uri] should be
+   *   well-formed and include a scheme (e.g., http, https) that applications can recognize and
+   *   handle.
+   * @return A set of package names of the best applications to handle the URI. If no suitable
+   *   application is found, it returns an empty set.
+   */
+  fun findAppForSso(uri: Uri): Set<String>
+}

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/AuthProviding.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/AuthProviding.kt
@@ -15,7 +15,6 @@
  */
 package com.uber.sdk2.auth.api
 
-import com.uber.sdk2.auth.api.internal.SsoLink
 import com.uber.sdk2.auth.api.response.AuthResult
 
 /** Provides a way to authenticate the user using SSO flow. */
@@ -26,5 +25,5 @@ interface AuthProviding {
    * @param ssoLink The SSO link to execute.
    * @return The result from the authentication flow encapsulated in [AuthResult]
    */
-  suspend fun authenticate(ssoLink: SsoLink): AuthResult
+  suspend fun authenticate(): AuthResult
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/AuthProviding.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/AuthProviding.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.sdk2.auth.api
+
+import com.uber.sdk2.auth.api.internal.SsoLink
+
+/** Provides a way to authenticate the user using SSO flow. */
+interface AuthProviding {
+  /**
+   * Executes the SSO flow.
+   *
+   * @param ssoLink The SSO link to execute.
+   */
+  suspend fun authenticate(ssoLink: SsoLink)
+}

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/AuthProviding.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/AuthProviding.kt
@@ -16,6 +16,7 @@
 package com.uber.sdk2.auth.api
 
 import com.uber.sdk2.auth.api.internal.SsoLink
+import com.uber.sdk2.auth.api.response.AuthResult
 
 /** Provides a way to authenticate the user using SSO flow. */
 interface AuthProviding {
@@ -23,6 +24,7 @@ interface AuthProviding {
    * Executes the SSO flow.
    *
    * @param ssoLink The SSO link to execute.
+   * @return The result from the authentication flow encapsulated in [AuthResult]
    */
-  suspend fun authenticate(ssoLink: SsoLink)
+  suspend fun authenticate(ssoLink: SsoLink): AuthResult
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/AuthProviding.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/AuthProviding.kt
@@ -18,7 +18,7 @@ package com.uber.sdk2.auth.api
 import com.uber.sdk2.auth.api.response.AuthResult
 
 /** Provides a way to authenticate the user using SSO flow. */
-interface AuthProviding {
+fun interface AuthProviding {
   /**
    * Executes the SSO flow.
    *

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/PKCEGenerator.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/PKCEGenerator.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.sdk2.auth.api
+
+/** Provides a way to generate PKCE code verifier and challenge. */
+interface PKCEGenerator {
+  /**
+   * Generates a code verifier.
+   *
+   * @return The generated code verifier.
+   */
+  fun generateCodeVerifier(): String
+
+  /**
+   * Generates a code challenge for the given code verifier.
+   *
+   * @param codeVerifier The code verifier for which the code challenge needs to be generated.
+   * @return The generated code challenge.
+   */
+  fun generateCodeChallenge(codeVerifier: String): String
+}

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/exception/AuthException.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/exception/AuthException.kt
@@ -31,7 +31,8 @@ sealed class AuthException(override val message: String) : RuntimeException(mess
 
     internal const val SCOPE_NOT_PROVIDED: String = "Scope not provided in the sso config file"
 
-    internal const val REDIRECT_URI_NOT_PROVIDED: String = "Redirect URI not provided in the sso config file"
+    internal const val REDIRECT_URI_NOT_PROVIDED: String =
+      "Redirect URI not provided in the sso config file"
 
     internal const val AUTH_CODE_INVALID = "Invalid auth code"
 

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/exception/AuthException.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/exception/AuthException.kt
@@ -25,4 +25,20 @@ sealed class AuthException(override val message: String) : RuntimeException(mess
 
   /** Represents the exception that occurred due to network error. */
   data class NetworkError(override val message: String) : AuthException(message)
+
+  companion object {
+    val CANCELED: String = "Canceled"
+
+    val SCOPE_NOT_PROVIDED: String = "Scope not provided in the sso config file"
+
+    val REDIRECT_URI_NOT_PROVIDED: String = "Redirect URI not provided in the sso config file"
+
+    val AUTH_CODE_INVALID = "Invalid auth code"
+
+    val EMPTY_RESPONSE = "Response is empty"
+
+    val NULL_RESPONSE = "Response not received"
+
+    val UNKNOWN = "Unknown error occurred"
+  }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/exception/AuthException.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/exception/AuthException.kt
@@ -27,18 +27,18 @@ sealed class AuthException(override val message: String) : RuntimeException(mess
   data class NetworkError(override val message: String) : AuthException(message)
 
   companion object {
-    val CANCELED: String = "Canceled"
+    internal const val CANCELED: String = "Canceled"
 
-    val SCOPE_NOT_PROVIDED: String = "Scope not provided in the sso config file"
+    internal const val SCOPE_NOT_PROVIDED: String = "Scope not provided in the sso config file"
 
-    val REDIRECT_URI_NOT_PROVIDED: String = "Redirect URI not provided in the sso config file"
+    internal const val REDIRECT_URI_NOT_PROVIDED: String = "Redirect URI not provided in the sso config file"
 
-    val AUTH_CODE_INVALID = "Invalid auth code"
+    internal const val AUTH_CODE_INVALID = "Invalid auth code"
 
-    val EMPTY_RESPONSE = "Response is empty"
+    internal const val EMPTY_RESPONSE = "Response is empty"
 
-    val NULL_RESPONSE = "Response not received"
+    internal const val NULL_RESPONSE = "Response not received"
 
-    val UNKNOWN = "Unknown error occurred"
+    internal const val UNKNOWN = "Unknown error occurred"
   }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/SsoConfig.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/request/SsoConfig.kt
@@ -17,19 +17,23 @@ package com.uber.sdk2.auth.api.request
 
 import android.content.Context
 import android.content.res.Resources
+import android.os.Parcelable
 import com.uber.sdk2.auth.api.exception.AuthException
 import com.uber.sdk2.core.config.UriConfig.CLIENT_ID_PARAM
 import com.uber.sdk2.core.config.UriConfig.REDIRECT_PARAM
 import com.uber.sdk2.core.config.UriConfig.SCOPE_PARAM
 import java.io.IOException
 import java.nio.charset.Charset
+import kotlinx.parcelize.Parcelize
 import okio.Buffer
 import okio.BufferedSource
 import okio.Okio
 import org.json.JSONException
 import org.json.JSONObject
 
-data class SsoConfig(val clientId: String, val redirectUri: String, val scope: String? = null)
+@Parcelize
+data class SsoConfig(val clientId: String, val redirectUri: String, val scope: String? = null) :
+  Parcelable
 
 object SsoConfigProvider {
   fun getSsoConfig(context: Context): SsoConfig {

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/response/AuthResult.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/response/AuthResult.kt
@@ -20,7 +20,7 @@ import com.uber.sdk2.auth.api.exception.AuthException
 /** Represents the response from the authentication request. */
 sealed class AuthResult {
   /** Represents the success response from the authentication request. */
-  data class Success(val uberToken: UberToken? = null) : AuthResult()
+  data class Success(val uberToken: UberToken) : AuthResult()
 
   /** Represents the error response from the authentication request. */
   data class Error(val authException: AuthException) : AuthResult()

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/response/AuthResult.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/response/AuthResult.kt
@@ -20,7 +20,7 @@ import com.uber.sdk2.auth.api.exception.AuthException
 /** Represents the response from the authentication request. */
 sealed class AuthResult {
   /** Represents the success response from the authentication request. */
-  data class Success(val authCode: String, val accessToken: AccessToken) : AuthResult()
+  data class Success(val uberToken: UberToken? = null) : AuthResult()
 
   /** Represents the error response from the authentication request. */
   data class Error(val authException: AuthException) : AuthResult()

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/response/PARResponse.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/response/PARResponse.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.sdk2.auth.api.response
+
+import com.squareup.moshi.Json
+
+data class PARResponse(
+  @Json(name = "request_uri") var requestUri: String,
+  @Json(name = "expires_in") var expiresIn: String,
+)

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/response/PARResponse.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/response/PARResponse.kt
@@ -18,6 +18,6 @@ package com.uber.sdk2.auth.api.response
 import com.squareup.moshi.Json
 
 data class PARResponse(
-  @Json(name = "request_uri") var requestUri: String,
-  @Json(name = "expires_in") var expiresIn: String,
+  @Json(name = "request_uri") val requestUri: String,
+  @Json(name = "expires_in") val expiresIn: String,
 )

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/response/UberToken.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/response/UberToken.kt
@@ -15,5 +15,16 @@
  */
 package com.uber.sdk2.auth.api.response
 
+import android.os.Parcelable
+import com.squareup.moshi.Json
+import kotlinx.parcelize.Parcelize
+
 /** Holds the OAuth token that is returned after a successful authentication request. */
-data class OAuthToken(val accessToken: AccessToken, val refreshToken: String)
+@Parcelize
+data class UberToken(
+  val authCode: String? = null,
+  @Json(name = "access_token") val accessToken: String? = null,
+  @Json(name = "access_token") val refreshToken: String? = null,
+  @Json(name = "expires_in") val expiresIn: Long? = null,
+  @Json(name = "scope") val scope: String? = null,
+) : Parcelable

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/sso/SsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/sso/SsoLink.kt
@@ -22,8 +22,6 @@ import kotlinx.coroutines.flow.Flow
  * flow
  */
 fun interface SsoLink {
-  /**
-   * Executes the SSO link with the given optional query parameters.
-   */
+  /** Executes the SSO link with the given optional query parameters. */
   suspend fun execute(optionalQueryParams: Map<String, String>): Flow<String>
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/sso/SsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/sso/SsoLink.kt
@@ -21,6 +21,9 @@ import kotlinx.coroutines.flow.Flow
  * Represents the Single Sign-On (SSO) link for authentication. This class is used to start the SSO
  * flow
  */
-interface SsoLink {
+fun interface SsoLink {
+  /**
+   * Executes the SSO link with the given optional query parameters.
+   */
   suspend fun execute(optionalQueryParams: Map<String, String>): Flow<String>
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/sso/SsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/sso/SsoLink.kt
@@ -13,7 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.uber.sdk2.auth.api.response
+package com.uber.sdk2.auth.api.sso
 
-/** Holds the access token that is returned after a successful authentication request. */
-data class AccessToken(val token: String, val scope: String, val expiresIn: Long)
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Represents the Single Sign-On (SSO) link for authentication. This class is used to start the SSO
+ * flow
+ */
+interface SsoLink {
+  suspend fun execute(optionalQueryParams: Map<String, String>): Flow<String>
+}


### PR DESCRIPTION
A few more classes added for scaffolding of the sdk. 
AppDiscovery: uses the app priority defined by the third party app to discover the best app to handle the sso flow
AuthProvider - Executes the sso flow
PARResponse - Holds a request_uri and it's expiration which can be sent to the backend as a query param for prefilling the profile information of the user
PKCEGenerator - Abstraction for generating a code challenge and verifier pair
