### PR TITLE
Update uri when adding optional query parameters

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
@@ -68,15 +68,18 @@ internal class UniversalSsoLink(
   override suspend fun execute(optionalQueryParams: Map<String, String>): String {
     val uri =
       UriConfig.assembleUri(
-        ssoConfig.clientId,
-        RESPONSE_TYPE,
-        ssoConfig.redirectUri,
-        ssoConfig.scope,
-      )
-
-    optionalQueryParams.entries.forEach { entry ->
-      uri.buildUpon().appendQueryParameter(entry.key, entry.value).build()
-    }
+          ssoConfig.clientId,
+          RESPONSE_TYPE,
+          ssoConfig.redirectUri,
+          ssoConfig.scope,
+        )
+        .buildUpon()
+        .also { builder ->
+          optionalQueryParams.entries.forEach { entry ->
+            builder.appendQueryParameter(entry.key, entry.value)
+          }
+        }
+        .build()
     withContext(Dispatchers.Main) {
       when (authContext.authDestination) {
         is AuthDestination.CrossAppSso -> {

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLinkTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLinkTest.kt
@@ -35,6 +35,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -130,5 +131,20 @@ class UniversalSsoLinkTest : RobolectricTestBase() {
 
       assertNotNull(result)
       assertEquals("authCode", result)
+    }
+
+  @Test
+  fun `execute when query params are provided and auth destination is InApp should updated the uri`() =
+    runTest(testDispatcher) {
+      universalSsoLink.resultDeferred.complete("SuccessResult")
+      whenever(appDiscovering.findAppForSso(any(), any())).thenReturn(null)
+      doNothing().whenever(customTabsLauncher).launch(any())
+
+      // Simulate calling execute and handle outcomes.
+      val result = universalSsoLink.execute(mapOf("param1" to "value1"))
+
+      assertNotNull(result)
+      assertEquals("SuccessResult", result)
+      verify(customTabsLauncher).launch(argThat { getQueryParameter("param1") == "value1" })
     }
 }


### PR DESCRIPTION
When optional query parameters were passed the uri wasn't updated with these params. This PR fixes the issue and adds unit test to verify the query params in the uri