### PR TITLE
Propagate the error message for failed sso back to the caller

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/api/exception/AuthException.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/api/exception/AuthException.kt
@@ -36,7 +36,7 @@ sealed class AuthException(override val message: String) : RuntimeException(mess
 
     internal const val AUTH_CODE_INVALID = "Invalid auth code"
 
-    internal const val EMPTY_RESPONSE = "Response is empty"
+    internal const val AUTH_CODE_NOT_PRESENT = "Auth code is not present"
 
     internal const val NULL_RESPONSE = "Response not received"
 

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
@@ -109,11 +109,9 @@ internal class UniversalSsoLink(
           throw AuthException.ClientError(AuthException.AUTH_CODE_NOT_PRESENT)
         } ?: throw AuthException.ClientError(AuthException.NULL_RESPONSE)
       }
-
       RESULT_CANCELED -> {
-        result.data?.getStringExtra(EXTRA_ERROR)?.let {
-          throw AuthException.ClientError(it)
-        } ?: throw AuthException.ClientError(AuthException.CANCELED)
+        result.data?.getStringExtra(EXTRA_ERROR)?.let { throw AuthException.ClientError(it) }
+          ?: throw AuthException.ClientError(AuthException.CANCELED)
       }
       else -> {
         // should never happen

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
@@ -17,7 +17,6 @@ package com.uber.sdk2.auth.internal.sso
 
 import android.content.Intent
 import android.net.Uri
-import android.provider.DocumentsContract.EXTRA_ERROR
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting


### PR DESCRIPTION
If the SSO with cross app flow does not work out due to some error then we need to propagate the same error back to the client. The previous implementation consumed the error and emitted just as canceled but there could be something wrong like bad redirect_uri or scope etc. so we want to be able to provide the right message to the caller