### PR TITLE
Added code challenge method as a query param

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
@@ -70,7 +70,7 @@ internal class UniversalSsoLink(
           ssoConfig.clientId,
           RESPONSE_TYPE,
           ssoConfig.redirectUri,
-          ssoConfig.scope,
+          scopes = ssoConfig.scope,
         )
         .buildUpon()
         .also { builder ->

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
   implementation(libs.appCompat)
   implementation(libs.material)
   testImplementation(libs.junit.junit)
+  testImplementation(libs.robolectric)
   androidTestImplementation(libs.androidx.test.ext.junit)
   androidTestImplementation(libs.androidx.test.espresso.espresso.core)
 }

--- a/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
+++ b/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
@@ -50,29 +50,33 @@ object UriConfig {
     clientId: String,
     responseType: String,
     redirectUri: String,
+    environment: Environment = AUTH,
+    path: String = AUTHORIZE_PATH,
     scopes: String? = null,
   ): Uri {
     val builder = Uri.Builder()
     builder
       .scheme(HTTPS.scheme)
-      .authority(AUTH.subDomain + "." + DEFAULT.domain)
-      .appendEncodedPath(PATH)
+      .authority(environment.subDomain + "." + DEFAULT.domain)
+      .appendEncodedPath(AUTHORIZE_PATH)
       .appendQueryParameter(CLIENT_ID_PARAM, clientId)
       .appendQueryParameter(RESPONSE_TYPE_PARAM, responseType.lowercase(Locale.US))
       .appendQueryParameter(REDIRECT_PARAM, redirectUri)
       .appendQueryParameter(SCOPE_PARAM, scopes)
       .appendQueryParameter(SDK_VERSION_PARAM, BuildConfig.VERSION_NAME)
+      .appendQueryParameter(PLATFORM_PARAM, "android")
+      .appendQueryParameter(CODE_CHALLENGE_METHOD, CODE_CHALLENGE_METHOD_VAL)
     return builder.build()
   }
 
   /** Gets the endpoint host used to hit the Uber API. */
-  fun getEndpointHost(): String = "${HTTPS.scheme}://$API.${DEFAULT.domain}"
+  fun getEndpointHost(): String = "${HTTPS.scheme}://${API.subDomain}.${DEFAULT.domain}"
 
   /** Gets the login host used to sign in to the Uber API. */
-  fun getAuthHost(): String = "${HTTPS.scheme}://$AUTH.${DEFAULT.domain}"
+  fun getAuthHost(): String = "${HTTPS.scheme}://${AUTH.subDomain}.${DEFAULT.domain}"
 
   const val CLIENT_ID_PARAM = "client_id"
-  const val PATH = "oauth/v2/universal/authorize"
+  const val AUTHORIZE_PATH = "oauth/v2/universal/authorize/"
   const val REDIRECT_PARAM = "redirect_uri"
   const val RESPONSE_TYPE_PARAM = "response_type"
   const val SCOPE_PARAM = "scope"
@@ -80,4 +84,6 @@ object UriConfig {
   const val SDK_VERSION_PARAM = "sdk_version"
   const val CODE_CHALLENGE_PARAM = "code_challenge"
   const val REQUEST_URI = "request_uri"
+  const val CODE_CHALLENGE_METHOD = "code_challenge_method"
+  const val CODE_CHALLENGE_METHOD_VAL = "S256"
 }

--- a/core/src/test/kotlin/com/uber/sdk2/core/RobolectricTestBase.kt
+++ b/core/src/test/kotlin/com/uber/sdk2/core/RobolectricTestBase.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.sdk2.core
+
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class) @Config(sdk = [26]) abstract class RobolectricTestBase {}

--- a/core/src/test/kotlin/com/uber/sdk2/core/UriConfigTest.kt
+++ b/core/src/test/kotlin/com/uber/sdk2/core/UriConfigTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.sdk2.core
+
+import com.uber.sdk2.core.config.UriConfig
+import com.uber.sdk2.core.config.UriConfig.AUTHORIZE_PATH
+import com.uber.sdk2.core.config.UriConfig.CLIENT_ID_PARAM
+import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_METHOD
+import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_METHOD_VAL
+import com.uber.sdk2.core.config.UriConfig.PLATFORM_PARAM
+import com.uber.sdk2.core.config.UriConfig.REDIRECT_PARAM
+import com.uber.sdk2.core.config.UriConfig.RESPONSE_TYPE_PARAM
+import com.uber.sdk2.core.config.UriConfig.SCOPE_PARAM
+import com.uber.sdk2.core.config.UriConfig.SDK_VERSION_PARAM
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UriConfigTest : RobolectricTestBase() {
+  @Test
+  fun `assembleUri should return correct uri`() {
+    val clientId = "clientI"
+    val responseType = "responseType"
+    val redirectUri = "redirectUri"
+    val scopes = "scopes"
+    val uri = UriConfig.assembleUri(clientId, responseType, redirectUri, scopes = scopes)
+    println(uri.toString())
+    assertEquals("auth.uber.com", uri.authority)
+    assertEquals("https", uri.scheme)
+    assertEquals("/$AUTHORIZE_PATH", uri.path)
+    assertEquals(clientId, uri.getQueryParameter(CLIENT_ID_PARAM))
+    assertEquals(responseType.lowercase(Locale.US), uri.getQueryParameter(RESPONSE_TYPE_PARAM))
+    assertEquals(redirectUri, uri.getQueryParameter(REDIRECT_PARAM))
+    assertEquals(scopes, uri.getQueryParameter(SCOPE_PARAM))
+    assertEquals(BuildConfig.VERSION_NAME, uri.getQueryParameter(SDK_VERSION_PARAM))
+    assertEquals("android", uri.getQueryParameter(PLATFORM_PARAM))
+    assertEquals(CODE_CHALLENGE_METHOD_VAL, uri.getQueryParameter(CODE_CHALLENGE_METHOD))
+  }
+
+  @Test
+  fun `getEndpointHost should return correct host`() {
+    assertEquals("https://api.uber.com", UriConfig.getEndpointHost())
+  }
+
+  @Test
+  fun `getAuthHost should return correct host`() {
+    assertEquals("https://auth.uber.com", UriConfig.getAuthHost())
+  }
+}


### PR DESCRIPTION
Description:
When launching the authorization flow we add a bunch of query parameters including a `code_challenge` which is part of the PKCE flow https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-pkce

There were some recent changes made on the backend to adhere to the pkce spec which required adding `code_challenge_method` as a query param from the callers. The sdk wasn't doing that before which resulted in invalid grant type error. So, adding the required parameter to comply with the spec.