### PR TITLE
Fixed bug with inApp authentication flow

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthActivity.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthActivity.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.launch
 class AuthActivity : AppCompatActivity() {
 
   private var authProvider: AuthProviding? = null
+  private var authStarted: Boolean = false
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -41,7 +42,6 @@ class AuthActivity : AppCompatActivity() {
         ?: throw IllegalStateException("AuthContext is required")
 
     authProvider = AuthProvider(this, authContext)
-    init()
   }
 
   private fun init() {
@@ -71,6 +71,12 @@ class AuthActivity : AppCompatActivity() {
 
   override fun onResume() {
     super.onResume()
+
+    if (!authStarted) {
+      init()
+      authStarted = true
+      return
+    }
     // Check if the intent has the auth code. This happens when user has authenticated using custom
     // tabs
     intent?.data?.let {
@@ -80,8 +86,9 @@ class AuthActivity : AppCompatActivity() {
       }
       authProvider?.handleAuthCode(authCode)
     }
-      ?: {
+      ?: run {
         // If the intent does not have the auth code, then the user has cancelled the authentication
+        setResult(RESULT_CANCELED, intent)
         finish()
       }
   }


### PR DESCRIPTION
• A flag is needed to denote that the auth flow has started.
• If auth flow has not started then start the auth flow from onResume() method of the AuthActivity
• If the onResume() method gets invoked again without any intent.data and authStarted flag is true that means auth flow was canceled so finish the activity