### PR TITLE
Fixed bug with authentication flow

### DIFF
--- a/authentication/build.gradle.kts
+++ b/authentication/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.kotlin.parcelize)
   alias(libs.plugins.spotless)
+  alias(libs.plugins.mavenPublish)
 }
 
 tasks.withType<KotlinCompile>().configureEach {
@@ -35,7 +36,11 @@ tasks.withType<KotlinCompile>().configureEach {
 
 android {
   namespace = "com.uber.sdk2.auth"
+  buildFeatures { buildConfig = true }
 
+  defaultConfig {
+    buildConfigField("String", "VERSION_NAME", "\"${project.property("VERSION_NAME").toString()}\"")
+  }
   defaultConfig {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("consumer-proguard-rules.txt")

--- a/authentication/gradle.properties
+++ b/authentication/gradle.properties
@@ -18,5 +18,5 @@ POM_NAME=Uber Authentication SDK (Android)
 POM_ARTIFACT_ID=authentication
 POM_PACKAGING=aar
 POM_DESCRIPTION=The official Uber Core Android SDK.
-version=2.0.0-SNAPSHOT
-VERSION_NAME=2.0.0-SNAPSHOT
+version=2.0.0
+VERSION_NAME=2.0.0

--- a/authentication/gradle.properties
+++ b/authentication/gradle.properties
@@ -18,3 +18,5 @@ POM_NAME=Uber Authentication SDK (Android)
 POM_ARTIFACT_ID=authentication
 POM_PACKAGING=aar
 POM_DESCRIPTION=The official Uber Core Android SDK.
+version=2.0.0-SNAPSHOT
+VERSION_NAME=2.0.0-SNAPSHOT

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/AuthProviding.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/AuthProviding.kt
@@ -29,4 +29,7 @@ interface AuthProviding {
 
   /** Handles the authentication code received from the SSO flow via deeplink. */
   fun handleAuthCode(authCode: String)
+
+  /** Checks if the authentication is in progress. */
+  fun isAuthInProgress(): Boolean
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -98,4 +98,8 @@ class AuthProvider(
   override fun handleAuthCode(authCode: String) {
     ssoLink.handleAuthCode(authCode)
   }
+
+  override fun isAuthInProgress(): Boolean {
+    return ssoLink.isAuthInProgress()
+  }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
@@ -54,6 +54,7 @@ internal class UniversalSsoLink(
 ) : SsoLink {
 
   @VisibleForTesting val resultDeferred = CompletableDeferred<String>()
+  private var isAuthInProgress: Boolean = false
 
   private val launcher =
     activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -62,6 +63,7 @@ internal class UniversalSsoLink(
       } catch (e: AuthException) {
         resultDeferred.completeExceptionally(e)
       }
+      isAuthInProgress = true
     }
 
   override suspend fun execute(optionalQueryParams: Map<String, String>): String {
@@ -117,6 +119,10 @@ internal class UniversalSsoLink(
         throw AuthException.ClientError(AuthException.UNKNOWN)
       }
     }
+  }
+
+  override fun isAuthInProgress(): Boolean {
+    return isAuthInProgress
   }
 
   private fun loadCustomtab(uri: Uri) {

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/sso/SsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/sso/SsoLink.kt
@@ -25,4 +25,7 @@ interface SsoLink {
 
   /** Handles the authentication code received from the SSO flow via deeplink. */
   fun handleAuthCode(authCode: String)
+
+  /** Checks if the authentication is in progress. */
+  fun isAuthInProgress(): Boolean
 }

--- a/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
+++ b/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
@@ -76,7 +76,7 @@ object UriConfig {
   fun getAuthHost(): String = "${HTTPS.scheme}://${AUTH.subDomain}.${DEFAULT.domain}"
 
   const val CLIENT_ID_PARAM = "client_id"
-  const val AUTHORIZE_PATH = "oauth/v2/universal/authorize/"
+  const val AUTHORIZE_PATH = "oauth/v2/universal/authorize"
   const val REDIRECT_PARAM = "redirect_uri"
   const val RESPONSE_TYPE_PARAM = "response_type"
   const val SCOPE_PARAM = "scope"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 GROUP=com.uber.sdk2
 
 #Version is managed by Gradle Release Plugin
-version=2.0.0-SNAPSHOT
-VERSION_NAME=2.0.0-SNAPSHOT
+version=0.10.10-SNAPSHOT
+VERSION_NAME=0.10.10-SNAPSHOT
 POM_URL=https\://developer.uber.com
 
 POM_SCM_URL=https\://github.com/uber/rides-android-sdk/

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 GROUP=com.uber.sdk2
 
 #Version is managed by Gradle Release Plugin
-version=0.10.10-SNAPSHOT
-VERSION_NAME=0.10.10-SNAPSHOT
+version=0.10.11
+VERSION_NAME=0.10.11
 POM_URL=https\://developer.uber.com
 
 POM_SCM_URL=https\://github.com/uber/rides-android-sdk/


### PR DESCRIPTION
## Context
There are a couple of ways of performing authentication - sso via an Uber app or sso via custom tabs. There's a subtle difference in the implementation - with custom tabs the authCode is returned via the intent's data inside onNewIntent() callback. Whereas, for sso via app the authCode is returned via activity result listener. A bug got introduced when adding code to finish the `AuthActivity` inside onResume() when the intent's data is null.

## Issue
When the auth flow is launched in custom tabs and the intent data is null we need to finish the AuthActivity. But, this is also true when performing sso via any of the Uber apps. When the auth is finished in an Uber app we get back the result in the `AuthActivity` and it is resumed with `intent.data = null`. Due to this, the `AuthActivity` finished before it could perform token exchange and return it to the caller

## Solution
Added an api to mark auth in progress. Whenever we get a result back from the Uber app we mark auth is in progress. Inside the `onResume()` callback of `AuthActivity` we check if auth is in progress then don't finish. This allows us to complete the auth flow and return the result back to the caller. 

https://github.com/uber/rides-android-sdk/assets/1142433/c4998ba0-d55e-4812-bb80-da9291471c90

## Other fixes

- Propagate a proper error message back to the client app
- Added maven publish plugin to authentication module
- Added versioning for the authentication module
- Reverted back version for the entire repo (since we are not releasing any new version for rides-sdk)
