### PR TITLE
Fixed bug with inApp authentication

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
@@ -91,13 +91,16 @@ internal class UniversalSsoLink(
             intent.`package` = packageName
             intent.data = uri
             launcher.launch(intent)
-          } ?: loadCustomtab(uri)
+          } ?: loadCustomtab(getSecureWebviewUri(uri))
         }
-        is AuthDestination.InApp -> loadCustomtab(uri)
+        is AuthDestination.InApp -> loadCustomtab(getSecureWebviewUri(uri))
       }
     }
     return resultDeferred.await()
   }
+
+  private fun getSecureWebviewUri(uri: Uri) = uri.buildUpon().path(UriConfig.AUTHORIZE_PATH).build()
+
 
   override fun handleAuthCode(authCode: String) {
     resultDeferred.complete(authCode)

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
@@ -101,7 +101,6 @@ internal class UniversalSsoLink(
 
   private fun getSecureWebviewUri(uri: Uri) = uri.buildUpon().path(UriConfig.AUTHORIZE_PATH).build()
 
-
   override fun handleAuthCode(authCode: String) {
     resultDeferred.complete(authCode)
   }

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLinkTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLinkTest.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import org.hamcrest.MatcherAssert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -139,11 +138,8 @@ class UniversalSsoLinkTest : RobolectricTestBase() {
       assertNotNull(result)
       assertEquals("SuccessResult", result)
 
-      verify(customTabsLauncher).launch(
-        argThat {
-          this.path.equals("/${UriConfig.AUTHORIZE_PATH}")
-        }
-      )
+      verify(customTabsLauncher)
+        .launch(argThat { this.path.equals("/${UriConfig.AUTHORIZE_PATH}") })
     }
 
   @Test

--- a/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
+++ b/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
@@ -51,14 +51,14 @@ object UriConfig {
     responseType: String,
     redirectUri: String,
     environment: Environment = AUTH,
-    path: String = AUTHORIZE_PATH,
+    path: String = UNIVERSAL_AUTHORIZE_PATH,
     scopes: String? = null,
   ): Uri {
     val builder = Uri.Builder()
     builder
       .scheme(HTTPS.scheme)
       .authority(environment.subDomain + "." + DEFAULT.domain)
-      .appendEncodedPath(AUTHORIZE_PATH)
+      .appendEncodedPath(UNIVERSAL_AUTHORIZE_PATH)
       .appendQueryParameter(CLIENT_ID_PARAM, clientId)
       .appendQueryParameter(RESPONSE_TYPE_PARAM, responseType.lowercase(Locale.US))
       .appendQueryParameter(REDIRECT_PARAM, redirectUri)
@@ -76,7 +76,8 @@ object UriConfig {
   fun getAuthHost(): String = "${HTTPS.scheme}://${AUTH.subDomain}.${DEFAULT.domain}"
 
   const val CLIENT_ID_PARAM = "client_id"
-  const val AUTHORIZE_PATH = "oauth/v2/universal/authorize"
+  const val UNIVERSAL_AUTHORIZE_PATH = "oauth/v2/universal/authorize"
+  const val AUTHORIZE_PATH = "oauth/v2/authorize"
   const val REDIRECT_PARAM = "redirect_uri"
   const val RESPONSE_TYPE_PARAM = "response_type"
   const val SCOPE_PARAM = "scope"

--- a/core/src/test/kotlin/com/uber/sdk2/core/UriConfigTest.kt
+++ b/core/src/test/kotlin/com/uber/sdk2/core/UriConfigTest.kt
@@ -16,7 +16,7 @@
 package com.uber.sdk2.core
 
 import com.uber.sdk2.core.config.UriConfig
-import com.uber.sdk2.core.config.UriConfig.AUTHORIZE_PATH
+import com.uber.sdk2.core.config.UriConfig.UNIVERSAL_AUTHORIZE_PATH
 import com.uber.sdk2.core.config.UriConfig.CLIENT_ID_PARAM
 import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_METHOD
 import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_METHOD_VAL
@@ -40,7 +40,7 @@ class UriConfigTest : RobolectricTestBase() {
     println(uri.toString())
     assertEquals("auth.uber.com", uri.authority)
     assertEquals("https", uri.scheme)
-    assertEquals("/$AUTHORIZE_PATH", uri.path)
+    assertEquals("/$UNIVERSAL_AUTHORIZE_PATH", uri.path)
     assertEquals(clientId, uri.getQueryParameter(CLIENT_ID_PARAM))
     assertEquals(responseType.lowercase(Locale.US), uri.getQueryParameter(RESPONSE_TYPE_PARAM))
     assertEquals(redirectUri, uri.getQueryParameter(REDIRECT_PARAM))

--- a/core/src/test/kotlin/com/uber/sdk2/core/UriConfigTest.kt
+++ b/core/src/test/kotlin/com/uber/sdk2/core/UriConfigTest.kt
@@ -16,7 +16,6 @@
 package com.uber.sdk2.core
 
 import com.uber.sdk2.core.config.UriConfig
-import com.uber.sdk2.core.config.UriConfig.UNIVERSAL_AUTHORIZE_PATH
 import com.uber.sdk2.core.config.UriConfig.CLIENT_ID_PARAM
 import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_METHOD
 import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_METHOD_VAL
@@ -25,6 +24,7 @@ import com.uber.sdk2.core.config.UriConfig.REDIRECT_PARAM
 import com.uber.sdk2.core.config.UriConfig.RESPONSE_TYPE_PARAM
 import com.uber.sdk2.core.config.UriConfig.SCOPE_PARAM
 import com.uber.sdk2.core.config.UriConfig.SDK_VERSION_PARAM
+import com.uber.sdk2.core.config.UriConfig.UNIVERSAL_AUTHORIZE_PATH
 import java.util.Locale
 import org.junit.Assert.assertEquals
 import org.junit.Test


### PR DESCRIPTION
## Context
The consumer apps can use different authentication mechanisms to authenticate against Uber - using an Uber app or using inApp flow (leveraging custom tabs). We use the same app link for both forms of authentication

## Issue
If the authentication flow is chosen as `inApp` but there's an Uber app installed that is capable of intercepting the app link then it is possible that in the middle of the `inApp` flow an Uber app gets launched due to a redirect from the web.

## Fix
For `inApp` flow we use a different url from the url for Uber app sso flow. For sso the path is `oauth/v2/universal/authorize` but for `inApp` the path is `oauth/v2/authorize`. This ensures that no app can intercept the redirect from the web and user can successfully complete the flow on web.

