### PR TITLE
Add code challenge param only with pkce authType

### DIFF
--- a/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
+++ b/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
@@ -65,7 +65,6 @@ object UriConfig {
       .appendQueryParameter(SCOPE_PARAM, scopes)
       .appendQueryParameter(SDK_VERSION_PARAM, BuildConfig.VERSION_NAME)
       .appendQueryParameter(PLATFORM_PARAM, "android")
-      .appendQueryParameter(CODE_CHALLENGE_METHOD, CODE_CHALLENGE_METHOD_VAL)
     return builder.build()
   }
 

--- a/core/src/test/kotlin/com/uber/sdk2/core/UriConfigTest.kt
+++ b/core/src/test/kotlin/com/uber/sdk2/core/UriConfigTest.kt
@@ -17,8 +17,6 @@ package com.uber.sdk2.core
 
 import com.uber.sdk2.core.config.UriConfig
 import com.uber.sdk2.core.config.UriConfig.CLIENT_ID_PARAM
-import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_METHOD
-import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_METHOD_VAL
 import com.uber.sdk2.core.config.UriConfig.PLATFORM_PARAM
 import com.uber.sdk2.core.config.UriConfig.REDIRECT_PARAM
 import com.uber.sdk2.core.config.UriConfig.RESPONSE_TYPE_PARAM
@@ -47,7 +45,6 @@ class UriConfigTest : RobolectricTestBase() {
     assertEquals(scopes, uri.getQueryParameter(SCOPE_PARAM))
     assertEquals(BuildConfig.VERSION_NAME, uri.getQueryParameter(SDK_VERSION_PARAM))
     assertEquals("android", uri.getQueryParameter(PLATFORM_PARAM))
-    assertEquals(CODE_CHALLENGE_METHOD_VAL, uri.getQueryParameter(CODE_CHALLENGE_METHOD))
   }
 
   @Test


### PR DESCRIPTION
If the code challenge param is added for authType = AuthCode then backend expects a code verifier too. This blocks clients who are using the 3-legged oauth flow using oauth client secret since they do not have a code verifier.
So, this param should not be sent for AuthCode auth type.