### PR TITLE
Added prompt parameter for sso authorization

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -99,16 +99,12 @@ class AuthProvider(
     } ?: PARResponse("", "")
 
   private fun getQueryParams(parResponse: PARResponse) = buildMap {
-    when (authContext.authType) {
-      AuthType.AuthCode -> {
-        parResponse.requestUri.takeIf { it.isNotEmpty() }?.let { put(REQUEST_URI, it) }
-      }
-      is AuthType.PKCE -> {
-        val codeChallenge = codeVerifierGenerator.generateCodeChallenge(verifier)
-        parResponse.requestUri.takeIf { it.isNotEmpty() }?.let { put(REQUEST_URI, it) }
-        put(CODE_CHALLENGE_PARAM, codeChallenge)
-        put(UriConfig.CODE_CHALLENGE_METHOD, UriConfig.CODE_CHALLENGE_METHOD_VAL)
-      }
+    parResponse.requestUri.takeIf { it.isNotEmpty() }?.let { put(REQUEST_URI, it) }
+    authContext.prompt?.let { put(UriConfig.PROMPT_PARAM, it.value) }
+    if (authContext.authType is AuthType.PKCE) {
+      val codeChallenge = codeVerifierGenerator.generateCodeChallenge(verifier)
+      put(CODE_CHALLENGE_PARAM, codeChallenge)
+      put(UriConfig.CODE_CHALLENGE_METHOD, UriConfig.CODE_CHALLENGE_METHOD_VAL)
     }
   }
 

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/request/AuthContext.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/request/AuthContext.kt
@@ -23,8 +23,8 @@ import kotlinx.parcelize.Parcelize
  *
  * @param authDestination The destination app to authenticate the user.
  * @param authType The type of authentication to perform.
- * @param prefillInfo The prefill information to be used for the authentication.
- * @param scopes The scopes to request for the authentication.
+ * @param prefillInfo The prefill information to be used for the authentication. This is optional.
+ * @param prompt The [Prompt] to be used for the authentication. This is optional.
  */
 @Parcelize
 data class AuthContext
@@ -33,4 +33,5 @@ constructor(
   val authDestination: AuthDestination = AuthDestination.CrossAppSso(),
   val authType: AuthType = AuthType.PKCE(),
   val prefillInfo: PrefillInfo? = null,
+  val prompt: Prompt? = null,
 ) : Parcelable

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/request/Prompt.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/request/Prompt.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.sdk2.auth.request
+
+/**
+ * Represents the prompt parameter for the OAuth 2.0 authorization request.
+ * https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest:~:text=select_account-,The,-Authorization%20Server%20SHOULD
+ */
+enum class Prompt(val value: String) {
+
+  /** The user will be prompted to login and authorize the app. */
+  LOGIN("login"),
+
+  /** The user will be prompted to authorize the app. */
+  CONSENT("consent")
+}

--- a/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
+++ b/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
@@ -86,4 +86,5 @@ object UriConfig {
   const val REQUEST_URI = "request_uri"
   const val CODE_CHALLENGE_METHOD = "code_challenge_method"
   const val CODE_CHALLENGE_METHOD_VAL = "S256"
+  const val PROMPT_PARAM = "prompt"
 }


### PR DESCRIPTION
Description:
As per the openid [spec](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest:~:text=select_account-,The,-Authorization%20Server%20SHOULD) a prompt parameter could be added to the url to present an appropriate webpage to the user. It can be used to force user to login again or provide consent etc. This change adds currently supported values of the `prompt` parameter to the sdk. We will update the sdk when Uber backend supports other values 