### PR TITLE
Switching to use startActivity with flags instead of startActivityForResult

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/AuthProviding.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/AuthProviding.kt
@@ -35,7 +35,4 @@ interface AuthProviding {
 
   /** Handles the authentication code received from the SSO flow via deeplink. */
   fun handleAuthCode(authCode: String)
-
-  /** Checks if the authentication is in progress. */
-  fun isAuthInProgress(): Boolean
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -117,8 +117,4 @@ class AuthProvider(
   override fun handleAuthCode(authCode: String) {
     ssoLink.handleAuthCode(authCode)
   }
-
-  override fun isAuthInProgress(): Boolean {
-    return ssoLink.isAuthInProgress()
-  }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/sso/SsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/sso/SsoLink.kt
@@ -31,7 +31,4 @@ interface SsoLink {
 
   /** Handles the authentication code received from the SSO flow via deeplink. */
   fun handleAuthCode(authCode: String)
-
-  /** Checks if the authentication is in progress. */
-  fun isAuthInProgress(): Boolean
 }


### PR DESCRIPTION
Previously we were resulting on startActivityForResult to invoke an Uber app for sso. This results in subpar UX and is buggy because it creates a new instance of the Uber app's activity which shows on top of the third party's app stack. So, we are changing the implementation a little big and returning the result via redirect uri that was passed using the sso_config.json configuration from the third party app.
The authCode will be passed in the fragment of the redirect uri as mentioned in this [RFC](https://datatracker.ietf.org/doc/html/rfc6749) 
The authCode will only be returned if all other config information that was setup on the Uber developer dash for the third party app matches with the authorization request.
This does not change the integration point of the calling app but is a change inside the sdk itself.

Also, adding calling app package to the intent to have a sanity validation on the Uber app for redirect uri match