### PR TITLE
Add UberEnvironment to allow 3Ps to target sandbox vs production

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -45,7 +45,7 @@ import kotlinx.coroutines.withContext
 class AuthProvider(
   private val activity: AppCompatActivity,
   private val authContext: AuthContext,
-  private val authService: AuthService = AuthService.create(),
+  private val authService: AuthService = AuthService.create(authContext.environment.baseUrl),
   private val codeVerifierGenerator: PKCEGenerator = PKCEGeneratorImpl,
 ) : AuthProviding {
   private val verifier: String = codeVerifierGenerator.generateCodeVerifier()

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/service/AuthService.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/service/AuthService.kt
@@ -57,10 +57,10 @@ interface AuthService {
 
   companion object {
     /** Creates an instance of [AuthService]. */
-    fun create(): AuthService {
+    fun create(baseUrl: String = UriConfig.UberEnvironment.PRODUCTION.baseUrl): AuthService {
       val moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
       return Retrofit.Builder()
-        .baseUrl(UriConfig.getAuthHost())
+        .baseUrl(baseUrl)
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .build()
         .create(AuthService::class.java)

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/SsoLinkFactory.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/SsoLinkFactory.kt
@@ -34,12 +34,6 @@ object SsoLinkFactory {
   fun generateSsoLink(activity: AppCompatActivity, authContext: AuthContext): SsoLink {
     val ssoConfig = SsoConfigProvider.getSsoConfig(activity)
     val appDiscovering = AppDiscovery(activity)
-    return UniversalSsoLink(
-      activity,
-      ssoConfig,
-      authContext,
-      appDiscovering,
-      authContext.environment,
-    )
+    return UniversalSsoLink(activity, ssoConfig, authContext, appDiscovering)
   }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/SsoLinkFactory.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/SsoLinkFactory.kt
@@ -34,6 +34,12 @@ object SsoLinkFactory {
   fun generateSsoLink(activity: AppCompatActivity, authContext: AuthContext): SsoLink {
     val ssoConfig = SsoConfigProvider.getSsoConfig(activity)
     val appDiscovering = AppDiscovery(activity)
-    return UniversalSsoLink(activity, ssoConfig, authContext, appDiscovering)
+    return UniversalSsoLink(
+      activity,
+      ssoConfig,
+      authContext,
+      appDiscovering,
+      authContext.environment,
+    )
   }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
@@ -55,7 +55,6 @@ internal class UniversalSsoLink(
   private val ssoConfig: SsoConfig,
   private val authContext: AuthContext,
   private val appDiscovering: AppDiscovering,
-  private val environment: UriConfig.UberEnvironment = UriConfig.UberEnvironment.PRODUCTION,
   private val customTabsLauncher: CustomTabsLauncher = CustomTabsLauncherImpl(activity),
 ) : SsoLink {
 
@@ -67,7 +66,7 @@ internal class UniversalSsoLink(
           ssoConfig.clientId,
           RESPONSE_TYPE,
           ssoConfig.redirectUri,
-          uberEnvironment = environment,
+          uberEnvironment = authContext.environment,
           scopes = ssoConfig.scope,
         )
         .buildUpon()

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
@@ -55,6 +55,7 @@ internal class UniversalSsoLink(
   private val ssoConfig: SsoConfig,
   private val authContext: AuthContext,
   private val appDiscovering: AppDiscovering,
+  private val environment: UriConfig.UberEnvironment = UriConfig.UberEnvironment.PRODUCTION,
   private val customTabsLauncher: CustomTabsLauncher = CustomTabsLauncherImpl(activity),
 ) : SsoLink {
 
@@ -66,6 +67,7 @@ internal class UniversalSsoLink(
           ssoConfig.clientId,
           RESPONSE_TYPE,
           ssoConfig.redirectUri,
+          uberEnvironment = environment,
           scopes = ssoConfig.scope,
         )
         .buildUpon()

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/request/AuthContext.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/request/AuthContext.kt
@@ -32,6 +32,9 @@ import kotlinx.parcelize.Parcelize
  * @param authType The type of authentication to perform.
  * @param prefillInfo The prefill information to be used for the authentication. This is optional.
  * @param prompt The [Prompt] to be used for the authentication. This is optional.
+ * @param environment The [UriConfig.UberEnvironment] to target for OAuth flows. Defaults to
+ *   [UriConfig.UberEnvironment.PRODUCTION]. Use [UriConfig.UberEnvironment.SANDBOX] to target
+ *   Uber's sandbox environment for development and testing.
  */
 @Parcelize
 data class AuthContext

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/request/AuthContext.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/request/AuthContext.kt
@@ -22,6 +22,7 @@
 package com.uber.sdk2.auth.request
 
 import android.os.Parcelable
+import com.uber.sdk2.core.config.UriConfig
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -40,4 +41,5 @@ constructor(
   val authType: AuthType = AuthType.PKCE(),
   val prefillInfo: PrefillInfo? = null,
   val prompt: Prompt? = null,
+  val environment: UriConfig.UberEnvironment = UriConfig.UberEnvironment.PRODUCTION,
 ) : Parcelable

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -303,23 +303,4 @@ class AuthProviderTest : RobolectricTestBase() {
       )
     assertEquals(UriConfig.UberEnvironment.SANDBOX, authContext.environment)
   }
-
-  @Test
-  fun `test authenticate with SANDBOX environment succeeds`() = runTest {
-    whenever(ssoLink.execute(any())).thenReturn("code")
-    whenever(codeVerifierGenerator.generateCodeVerifier()).thenReturn("verifier")
-    whenever(codeVerifierGenerator.generateCodeChallenge("verifier")).thenReturn("challenge")
-    whenever(authService.token(any(), any(), any(), any(), any()))
-      .thenReturn(Response.success(UberToken(accessToken = "accessToken")))
-    val authContext =
-      AuthContext(
-        authDestination = AuthDestination.CrossAppSso(listOf(CrossApp.Rider)),
-        authType = AuthType.PKCE(),
-        environment = UriConfig.UberEnvironment.SANDBOX,
-      )
-    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
-    val result = authProvider.authenticate()
-    assert(result is AuthResult.Success)
-    assert((result as AuthResult.Success).uberToken.accessToken == "accessToken")
-  }
 }

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -46,6 +46,7 @@ import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_METHOD_VAL
 import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_PARAM
 import com.uber.sdk2.core.config.UriConfig.REQUEST_URI
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -278,6 +279,46 @@ class AuthProviderTest : RobolectricTestBase() {
     assert(argumentCaptor.lastValue[CODE_CHALLENGE_PARAM] == "challenge")
     assert(argumentCaptor.lastValue[CODE_CHALLENGE_METHOD] == CODE_CHALLENGE_METHOD_VAL)
     // Verify authentication succeeded
+    assert(result is AuthResult.Success)
+    assert((result as AuthResult.Success).uberToken.accessToken == "accessToken")
+  }
+
+  @Test
+  fun `test AuthContext defaults to PRODUCTION environment`() {
+    val authContext =
+      AuthContext(
+        authDestination = AuthDestination.CrossAppSso(listOf(CrossApp.Rider)),
+        authType = AuthType.PKCE(),
+      )
+    assertEquals(UriConfig.UberEnvironment.PRODUCTION, authContext.environment)
+  }
+
+  @Test
+  fun `test AuthContext with SANDBOX environment is set correctly`() {
+    val authContext =
+      AuthContext(
+        authDestination = AuthDestination.CrossAppSso(listOf(CrossApp.Rider)),
+        authType = AuthType.PKCE(),
+        environment = UriConfig.UberEnvironment.SANDBOX,
+      )
+    assertEquals(UriConfig.UberEnvironment.SANDBOX, authContext.environment)
+  }
+
+  @Test
+  fun `test authenticate with SANDBOX environment succeeds`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("code")
+    whenever(codeVerifierGenerator.generateCodeVerifier()).thenReturn("verifier")
+    whenever(codeVerifierGenerator.generateCodeChallenge("verifier")).thenReturn("challenge")
+    whenever(authService.token(any(), any(), any(), any(), any()))
+      .thenReturn(Response.success(UberToken(accessToken = "accessToken")))
+    val authContext =
+      AuthContext(
+        authDestination = AuthDestination.CrossAppSso(listOf(CrossApp.Rider)),
+        authType = AuthType.PKCE(),
+        environment = UriConfig.UberEnvironment.SANDBOX,
+      )
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val result = authProvider.authenticate()
     assert(result is AuthResult.Success)
     assert((result as AuthResult.Success).uberToken.accessToken == "accessToken")
   }

--- a/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
+++ b/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
@@ -25,7 +25,6 @@ import android.net.Uri
 import com.uber.sdk2.core.BuildConfig
 import com.uber.sdk2.core.config.UriConfig.EndpointRegion.DEFAULT
 import com.uber.sdk2.core.config.UriConfig.Environment.API
-import com.uber.sdk2.core.config.UriConfig.Environment.AUTH
 import com.uber.sdk2.core.config.UriConfig.Scheme.HTTPS
 import java.util.Locale
 
@@ -52,18 +51,24 @@ object UriConfig {
     DEFAULT("uber.com")
   }
 
+  /** Represents the Uber auth environment to target for OAuth flows. */
+  enum class UberEnvironment(val baseUrl: String) {
+    PRODUCTION("https://auth.uber.com"),
+    SANDBOX("https://sandbox-login.uber.com"),
+  }
+
   fun assembleUri(
     clientId: String,
     responseType: String,
     redirectUri: String,
-    environment: Environment = AUTH,
+    uberEnvironment: UberEnvironment = UberEnvironment.PRODUCTION,
     path: String = UNIVERSAL_AUTHORIZE_PATH,
     scopes: String? = null,
   ): Uri {
     val builder = Uri.Builder()
     builder
       .scheme(HTTPS.scheme)
-      .authority(environment.subDomain + "." + DEFAULT.domain)
+      .authority(Uri.parse(uberEnvironment.baseUrl).host)
       .appendEncodedPath(UNIVERSAL_AUTHORIZE_PATH)
       .appendQueryParameter(CLIENT_ID_PARAM, clientId)
       .appendQueryParameter(RESPONSE_TYPE_PARAM, responseType.lowercase(Locale.US))
@@ -78,7 +83,8 @@ object UriConfig {
   fun getEndpointHost(): String = "${HTTPS.scheme}://${API.subDomain}.${DEFAULT.domain}"
 
   /** Gets the login host used to sign in to the Uber API. */
-  fun getAuthHost(): String = "${HTTPS.scheme}://${AUTH.subDomain}.${DEFAULT.domain}"
+  fun getAuthHost(uberEnvironment: UberEnvironment = UberEnvironment.PRODUCTION): String =
+    uberEnvironment.baseUrl
 
   const val CLIENT_ID_PARAM = "client_id"
   const val UNIVERSAL_AUTHORIZE_PATH = "oauth/v2/universal/authorize"

--- a/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
+++ b/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
@@ -24,7 +24,6 @@ package com.uber.sdk2.core.config
 import android.net.Uri
 import com.uber.sdk2.core.BuildConfig
 import com.uber.sdk2.core.config.UriConfig.EndpointRegion.DEFAULT
-import com.uber.sdk2.core.config.UriConfig.Environment.API
 import com.uber.sdk2.core.config.UriConfig.Scheme.HTTPS
 import java.util.Locale
 
@@ -33,15 +32,6 @@ object UriConfig {
   enum class Scheme(val scheme: String) {
     HTTP("http"),
     HTTPS("https")
-  }
-
-  /**
-   * An Uber API Environment. See [Sandbox](https://developer.uber.com/v1/sandbox) for more
-   * information.
-   */
-  enum class Environment(val subDomain: String) {
-    API("api"),
-    AUTH("auth"),
   }
 
   enum class EndpointRegion(
@@ -80,7 +70,7 @@ object UriConfig {
   }
 
   /** Gets the endpoint host used to hit the Uber API. */
-  fun getEndpointHost(): String = "${HTTPS.scheme}://${API.subDomain}.${DEFAULT.domain}"
+  fun getEndpointHost(): String = "${HTTPS.scheme}://api.${DEFAULT.domain}"
 
   /** Gets the login host used to sign in to the Uber API. */
   fun getAuthHost(uberEnvironment: UberEnvironment = UberEnvironment.PRODUCTION): String =

--- a/core/src/test/kotlin/com/uber/sdk2/core/UriConfigTest.kt
+++ b/core/src/test/kotlin/com/uber/sdk2/core/UriConfigTest.kt
@@ -54,12 +54,54 @@ class UriConfigTest : RobolectricTestBase() {
   }
 
   @Test
+  fun `assembleUri with PRODUCTION environment should use auth uber com`() {
+    val uri =
+      UriConfig.assembleUri(
+        "clientId",
+        "code",
+        "redirectUri",
+        uberEnvironment = UriConfig.UberEnvironment.PRODUCTION,
+      )
+    assertEquals("auth.uber.com", uri.authority)
+    assertEquals("https", uri.scheme)
+  }
+
+  @Test
+  fun `assembleUri with SANDBOX environment should use sandbox-login uber com`() {
+    val uri =
+      UriConfig.assembleUri(
+        "clientId",
+        "code",
+        "redirectUri",
+        uberEnvironment = UriConfig.UberEnvironment.SANDBOX,
+      )
+    assertEquals("sandbox-login.uber.com", uri.authority)
+    assertEquals("https", uri.scheme)
+  }
+
+  @Test
   fun `getEndpointHost should return correct host`() {
     assertEquals("https://api.uber.com", UriConfig.getEndpointHost())
   }
 
   @Test
-  fun `getAuthHost should return correct host`() {
+  fun `getAuthHost with default should return production host`() {
     assertEquals("https://auth.uber.com", UriConfig.getAuthHost())
+  }
+
+  @Test
+  fun `getAuthHost with PRODUCTION should return auth uber com`() {
+    assertEquals(
+      "https://auth.uber.com",
+      UriConfig.getAuthHost(UriConfig.UberEnvironment.PRODUCTION),
+    )
+  }
+
+  @Test
+  fun `getAuthHost with SANDBOX should return sandbox-login uber com`() {
+    assertEquals(
+      "https://sandbox-login.uber.com",
+      UriConfig.getAuthHost(UriConfig.UberEnvironment.SANDBOX),
+    )
   }
 }


### PR DESCRIPTION
## Summary

Adds support for 3P developers to configure which Uber auth environment to target when integrating with the Android SDK.

Previously the SDK hardcoded `auth.uber.com` across all auth flows (`/authorize`, `/par`, `/token`) with no way to redirect to sandbox for testing.

**Changes:**
- Add `UberEnvironment` enum to `UriConfig` with `PRODUCTION` and `SANDBOX` cases, each mapping to its base URL
- Add optional `environment` field to `AuthContext` (defaults to `PRODUCTION` — fully backwards-compatible)
- Thread environment through `AuthService.create()`, `AuthProvider`, `SsoLinkFactory`, and `UniversalSsoLink` so all three OAuth endpoints respect the configured environment

**Usage:**
```kotlin
// Production (default — no change for existing integrations)
val authContext = AuthContext()

// Sandbox
val authContext = AuthContext(environment = UriConfig.UberEnvironment.SANDBOX)
```

## Test Plan

- Added unit tests verifying PRODUCTION and SANDBOX URLs for `assembleUri()` and `getAuthHost()`
- Added unit tests verifying `AuthContext` defaults to PRODUCTION and SANDBOX can be set
- Added unit test verifying authentication flow succeeds with SANDBOX environment
- All existing tests continue to pass unchanged

## Related

- Mirrors iOS SDK PR: https://github.com/uber/uber-ios-sdk/pull/332
- Jira: CIP-45474

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>