### PR TITLE
Fix missing ub__signin_margin dimen in :core that broke 3P authentication consumers

### DIFF
--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -22,5 +22,6 @@
     <dimen name="ub__standard_padding">16dp</dimen>
     <dimen name="ub__small_padding">8dp</dimen>
 
+    <dimen name="ub__signin_margin">48dp</dimen>
     <dimen name="ub__progress_bar_height">32dp</dimen>
 </resources>


### PR DESCRIPTION
## Summary

Reported by a 3P consumer of `com.uber.sdk2:authentication:2.0.3`:

> Android resource linking failed
> AAPT: error: resource dimen/ub__signin_margin not found.
>
> Worked around locally by defining `<dimen name="ub__signin_margin">48dp</dimen>`, but should be fixed in the SDK so other 3P developers don't hit the same error.

## Root cause

- `authentication/src/main/res/values/styles.xml` defines `UberButton.Login`, which references `@dimen/ub__signin_margin`.
- `:authentication` depends only on `:core` (the published `com.uber.sdk2:core`).
- `core/src/main/res/values/dimens.xml` mirrors most resources from the legacy `:core-android`, but `ub__signin_margin` was never copied over — it only existed in `:core-android`.
- 3P consumers pulling `com.uber.sdk2:authentication` get `:core` transitively, but not the missing dimen — hence the AAPT error.

The other resources the same style references (`ub__standard_padding`, `ub__secondary_text_size`, `@color/uber_black`, the `uber_logotype_*` drawables, `uber_button_background_selector_white`) were correctly mirrored into `:core`, which is why no other resource errors surfaced.

## Fix

Add `<dimen name="ub__signin_margin">48dp</dimen>` to `core/src/main/res/values/dimens.xml`, matching the value and position used in `:core-android`. One-line change, restores the mirror.

## Test plan

- [x] `./gradlew :authentication:assembleRelease` builds successfully (verified locally — AAPT now resolves `ub__signin_margin` for the AAR a 3P consumer pulls).
- [ ] 3P repro: consume `com.uber.sdk2:authentication` (built from this branch) in a sample app and confirm `Android resource linking failed` no longer occurs.