### PR TITLE
Forward optional nonce on /authorize request

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -117,6 +117,7 @@ class AuthProvider(
   private fun getQueryParams(parResponse: PARResponse) = buildMap {
     parResponse.requestUri.takeIf { it.isNotEmpty() }?.let { put(REQUEST_URI, it) }
     authContext.prompt?.let { put(UriConfig.PROMPT_PARAM, it.value) }
+    authContext.nonce?.let { put(UriConfig.NONCE_PARAM, it) }
     if (authContext.authType is AuthType.PKCE) {
       val codeChallenge = codeVerifierGenerator.generateCodeChallenge(verifier)
       put(CODE_CHALLENGE_PARAM, codeChallenge)

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/request/AuthContext.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/request/AuthContext.kt
@@ -35,6 +35,10 @@ import kotlinx.parcelize.Parcelize
  * @param environment The [UriConfig.UberEnvironment] to target for OAuth flows. Defaults to
  *   [UriConfig.UberEnvironment.PRODUCTION]. Use [UriConfig.UberEnvironment.SANDBOX] to target
  *   Uber's sandbox environment for development and testing.
+ * @param nonce An optional, opaque, single-use string sent on the `/authorize` request. Required by
+ *   the server when `openid` is one of the requested scopes; the same value is returned as the
+ *   `nonce` claim of the issued ID token and must be validated by the caller's backend to mitigate
+ *   token replay. The SDK does not generate, store, or validate the value — it only forwards it.
  */
 @Parcelize
 data class AuthContext
@@ -45,4 +49,5 @@ constructor(
   val prefillInfo: PrefillInfo? = null,
   val prompt: Prompt? = null,
   val environment: UriConfig.UberEnvironment = UriConfig.UberEnvironment.PRODUCTION,
+  val nonce: String? = null,
 ) : Parcelable

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -203,6 +203,40 @@ class AuthProviderTest : RobolectricTestBase() {
   }
 
   @Test
+  fun `test authenticate when nonce is present should forward it as query param`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("authCode")
+    whenever(authService.loginParRequest(any(), any(), any(), any()))
+      .thenReturn(Response.success(PARResponse("requestUri", "codeVerifier")))
+    val authContext =
+      AuthContext(
+        AuthDestination.CrossAppSso(listOf(CrossApp.Rider)),
+        AuthType.AuthCode,
+        null,
+        nonce = "n-0S6_WzA2Mj",
+      )
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val argumentCaptor = argumentCaptor<Map<String, String>>()
+    val result = authProvider.authenticate()
+    verify(ssoLink).execute(argumentCaptor.capture())
+    assert(argumentCaptor.lastValue[UriConfig.NONCE_PARAM] == "n-0S6_WzA2Mj")
+    assert(result is AuthResult.Success)
+  }
+
+  @Test
+  fun `test authenticate when nonce is absent should not include nonce query param`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("authCode")
+    whenever(authService.loginParRequest(any(), any(), any(), any()))
+      .thenReturn(Response.success(PARResponse("requestUri", "codeVerifier")))
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val argumentCaptor = argumentCaptor<Map<String, String>>()
+    authProvider.authenticate()
+    verify(ssoLink).execute(argumentCaptor.capture())
+    assert(argumentCaptor.lastValue.containsKey(UriConfig.NONCE_PARAM).not())
+  }
+
+  @Test
   fun `test authenticate when PAR request fails should continue without metadata`() = runTest {
     whenever(ssoLink.execute(any())).thenReturn("authCode")
     // Mock PAR request to return error response (e.g., 500)

--- a/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
+++ b/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
@@ -89,4 +89,5 @@ object UriConfig {
   const val CODE_CHALLENGE_METHOD = "code_challenge_method"
   const val CODE_CHALLENGE_METHOD_VAL = "S256"
   const val PROMPT_PARAM = "prompt"
+  const val NONCE_PARAM = "nonce"
 }


### PR DESCRIPTION
## Summary

The Uber auth server requires a `nonce` query parameter on `/authorize` when the requested scope includes `openid`. It echoes the value back as the `nonce` claim of the issued ID token so the caller's backend can verify it and reject replays. Today the Android SDK has no way for developers to supply one — there's only an `INVALID_NONCE` error enum on the receiving side.

This adds an optional `nonce: String?` field on `AuthContext`. When set, `AuthProvider` puts it into the `optionalQueryParams` map it already passes to `UniversalSsoLink.execute()`, which appends it to the `/authorize` URL. No signature change to `UriConfig.assembleUri()`, no behavior change when the caller doesn't set it.

The SDK does **not** generate, store, or validate the nonce — that responsibility stays with the caller's backend (which already has to maintain a server-wide dedupe set per the partner integration spec).

### Files changed

- `core/.../UriConfig.kt` — add `NONCE_PARAM = "nonce"` constant.
- `authentication/.../request/AuthContext.kt` — add `nonce: String?` field with KDoc.
- `authentication/.../internal/AuthProvider.kt` — include `nonce` in `getQueryParams()` when present.
- Tests — `AuthProviderTest` verifies the nonce is forwarded when present and absent when not.

### Test plan

- [x] `./gradlew :authentication:test :core:test` — green
- [x] `./gradlew :authentication:assemble :core:assemble :rides-android:assemble` — green
- [x] `./gradlew spotlessCheck` — green
- [ ] Reviewer to confirm spec interpretation: SDK forwards a caller-supplied nonce (does not auto-generate one when `openid` is in scope).

### Revert plan

Straight `git revert` — no migrations, only an additive optional field. Existing callers compile unchanged.