### PR TITLE
[auth] Add state (CSRF) parameter to OAuth flow

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/AuthProviding.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/AuthProviding.kt
@@ -34,5 +34,5 @@ interface AuthProviding {
   suspend fun authenticate(): AuthResult
 
   /** Handles the authentication code received from the SSO flow via deeplink. */
-  fun handleAuthCode(authCode: String)
+  fun handleAuthCode(authCode: String, state: String? = null)
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
@@ -48,6 +48,6 @@ sealed class AuthException(override val message: String) : RuntimeException(mess
 
     internal const val UNKNOWN = "Unknown error occurred"
 
-    internal const val INVALID_STATE = "State parameter mismatch - possible CSRF attack"
+    internal const val INVALID_STATE = "State parameter mismatch possible CSRF attack"
   }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
@@ -48,6 +48,6 @@ sealed class AuthException(override val message: String) : RuntimeException(mess
 
     internal const val UNKNOWN = "Unknown error occurred"
 
-    internal const val INVALID_STATE = "State parameter mismatch — possible CSRF attack"
+    internal const val INVALID_STATE = "State parameter mismatch - possible CSRF attack"
   }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
@@ -47,5 +47,7 @@ sealed class AuthException(override val message: String) : RuntimeException(mess
     internal const val NULL_RESPONSE = "Response not received"
 
     internal const val UNKNOWN = "Unknown error occurred"
+
+    internal const val INVALID_STATE = "State parameter mismatch — possible CSRF attack"
   }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthActivity.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthActivity.kt
@@ -102,8 +102,10 @@ class AuthActivity : AppCompatActivity() {
           }
         ?: ""
 
+    val state = uri.getQueryParameter(KEY_STATE)
+
     if (authCode.isNotEmpty()) {
-      authProvider?.handleAuthCode(authCode)
+      authProvider?.handleAuthCode(authCode, state)
     } else {
       val error =
         uri.getQueryParameter(KEY_ERROR)
@@ -131,6 +133,7 @@ class AuthActivity : AppCompatActivity() {
     private const val AUTH_CONTEXT = "auth_context"
     private const val KEY_AUTHENTICATION_CODE = "code"
     private const val KEY_ERROR = "error"
+    private const val KEY_STATE = "state"
 
     fun newIntent(context: Context, authContext: AuthContext): Intent {
       val intent = Intent(context, AuthActivity::class.java)

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -132,7 +132,7 @@ class AuthProvider(
   }
 
   override fun handleAuthCode(authCode: String, state: String?) {
-    if (state != null && state != generatedState) {
+    if (state != generatedState) {
       ssoLink.handleAuthError(AuthException.ClientError(AuthException.INVALID_STATE))
       return
     }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -21,6 +21,8 @@
  */
 package com.uber.sdk2.auth.internal
 
+import android.util.Base64
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import com.uber.sdk2.auth.AuthProviding
 import com.uber.sdk2.auth.PKCEGenerator
@@ -39,6 +41,7 @@ import com.uber.sdk2.auth.response.UberToken
 import com.uber.sdk2.core.config.UriConfig
 import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_PARAM
 import com.uber.sdk2.core.config.UriConfig.REQUEST_URI
+import java.security.SecureRandom
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -50,6 +53,8 @@ class AuthProvider(
 ) : AuthProviding {
   private val verifier: String = codeVerifierGenerator.generateCodeVerifier()
   private val ssoLink = SsoLinkFactory.generateSsoLink(activity, authContext)
+
+  @VisibleForTesting internal val generatedState: String = generateSecureToken()
 
   override suspend fun authenticate(): AuthResult {
     val ssoConfig = withContext(Dispatchers.IO) { SsoConfigProvider.getSsoConfig(activity) }
@@ -118,6 +123,7 @@ class AuthProvider(
     parResponse.requestUri.takeIf { it.isNotEmpty() }?.let { put(REQUEST_URI, it) }
     authContext.prompt?.let { put(UriConfig.PROMPT_PARAM, it.value) }
     authContext.nonce?.let { put(UriConfig.NONCE_PARAM, it) }
+    put(UriConfig.STATE_PARAM, generatedState)
     if (authContext.authType is AuthType.PKCE) {
       val codeChallenge = codeVerifierGenerator.generateCodeChallenge(verifier)
       put(CODE_CHALLENGE_PARAM, codeChallenge)
@@ -125,7 +131,17 @@ class AuthProvider(
     }
   }
 
-  override fun handleAuthCode(authCode: String) {
+  override fun handleAuthCode(authCode: String, state: String?) {
+    if (state != null && state != generatedState) {
+      ssoLink.handleAuthError(AuthException.ClientError(AuthException.INVALID_STATE))
+      return
+    }
     ssoLink.handleAuthCode(authCode)
+  }
+
+  private fun generateSecureToken(): String {
+    val bytes = ByteArray(32)
+    SecureRandom().nextBytes(bytes)
+    return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
   }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/sso/UniversalSsoLink.kt
@@ -102,6 +102,10 @@ internal class UniversalSsoLink(
     resultDeferred.complete(authCode)
   }
 
+  override fun handleAuthError(exception: AuthException) {
+    resultDeferred.completeExceptionally(exception)
+  }
+
   private fun handleResult(result: ActivityResult): String {
     return when (result.resultCode) {
       RESULT_OK -> {

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/sso/SsoLink.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/sso/SsoLink.kt
@@ -21,6 +21,8 @@
  */
 package com.uber.sdk2.auth.sso
 
+import com.uber.sdk2.auth.exception.AuthException
+
 /**
  * Represents the Single Sign-On (SSO) link for authentication. This class is used to start the SSO
  * flow
@@ -31,4 +33,7 @@ interface SsoLink {
 
   /** Handles the authentication code received from the SSO flow via deeplink. */
   fun handleAuthCode(authCode: String)
+
+  /** Signals an auth error so the suspended [execute] call completes exceptionally. */
+  fun handleAuthError(exception: AuthException)
 }

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -380,12 +380,12 @@ class AuthProviderTest : RobolectricTestBase() {
   }
 
   @Test
-  fun `handleAuthCode with null state skips state validation`() {
+  fun `handleAuthCode with null state triggers state mismatch error`() {
     val authContext =
       AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
     val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
     authProvider.handleAuthCode("authCode", null)
-    verify(ssoLink).handleAuthCode("authCode")
-    verify(ssoLink, never()).handleAuthError(any())
+    verify(ssoLink, never()).handleAuthCode(any())
+    verify(ssoLink).handleAuthError(argThat { message == AuthException.INVALID_STATE })
   }
 }

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -45,11 +45,13 @@ import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_METHOD
 import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_METHOD_VAL
 import com.uber.sdk2.core.config.UriConfig.CODE_CHALLENGE_PARAM
 import com.uber.sdk2.core.config.UriConfig.REQUEST_URI
+import com.uber.sdk2.core.config.UriConfig.STATE_PARAM
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -123,7 +125,8 @@ class AuthProviderTest : RobolectricTestBase() {
     assert(argumentCaptor.firstValue[CODE_CHALLENGE_PARAM] == "challenge")
     assert(argumentCaptor.firstValue[CODE_CHALLENGE_METHOD] == CODE_CHALLENGE_METHOD_VAL)
     assert(argumentCaptor.firstValue.containsValue(UriConfig.PROMPT_PARAM).not())
-    assert(argumentCaptor.firstValue.size == 3)
+    // request_uri + code_challenge + code_challenge_method + state = 4
+    assert(argumentCaptor.firstValue.size == 4)
     assert(result is AuthResult.Success)
     assert((result as AuthResult.Success).uberToken.accessToken == "accessToken")
   }
@@ -146,7 +149,8 @@ class AuthProviderTest : RobolectricTestBase() {
     verify(authService, never()).token(any(), any(), any(), any(), any())
     verify(ssoLink).execute(argumentCaptor.capture())
     assert(argumentCaptor.lastValue[REQUEST_URI] == "requestUri")
-    assert(argumentCaptor.lastValue.size == 1)
+    // request_uri + state = 2
+    assert(argumentCaptor.lastValue.size == 2)
     assert(result is AuthResult.Success)
     assert((result as AuthResult.Success).uberToken.authCode == "authCode")
   }
@@ -164,7 +168,9 @@ class AuthProviderTest : RobolectricTestBase() {
       val result = authProvider.authenticate()
       verify(authService, never()).token(any(), any(), any(), any(), any())
       verify(ssoLink).execute(argumentCaptor.capture())
-      assert(argumentCaptor.lastValue.isEmpty())
+      // state is always included; no request_uri when prefillInfo is null
+      assert(argumentCaptor.lastValue.size == 1)
+      assert(argumentCaptor.lastValue.containsKey(STATE_PARAM))
       assert(result is AuthResult.Success)
       assert((result as AuthResult.Success).uberToken.authCode == "authCode")
     }
@@ -336,5 +342,50 @@ class AuthProviderTest : RobolectricTestBase() {
         environment = UriConfig.UberEnvironment.SANDBOX,
       )
     assertEquals(UriConfig.UberEnvironment.SANDBOX, authContext.environment)
+  }
+
+  // ---- State (CSRF) tests ----
+
+  @Test
+  fun `state is always included in query params`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("authCode")
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val captor = argumentCaptor<Map<String, String>>()
+    authProvider.authenticate()
+    verify(ssoLink).execute(captor.capture())
+    assert(captor.lastValue.containsKey(STATE_PARAM))
+    assert(captor.lastValue[STATE_PARAM]!!.isNotEmpty())
+  }
+
+  @Test
+  fun `handleAuthCode with matching state completes normally`() {
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    authProvider.handleAuthCode("authCode", authProvider.generatedState)
+    verify(ssoLink).handleAuthCode("authCode")
+    verify(ssoLink, never()).handleAuthError(any())
+  }
+
+  @Test
+  fun `handleAuthCode with state mismatch signals error on ssoLink`() {
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    authProvider.handleAuthCode("authCode", "tampered-state-value")
+    verify(ssoLink, never()).handleAuthCode(any())
+    verify(ssoLink).handleAuthError(argThat { message == AuthException.INVALID_STATE })
+  }
+
+  @Test
+  fun `handleAuthCode with null state skips state validation`() {
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    authProvider.handleAuthCode("authCode", null)
+    verify(ssoLink).handleAuthCode("authCode")
+    verify(ssoLink, never()).handleAuthError(any())
   }
 }

--- a/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
+++ b/core/src/main/kotlin/com/uber/sdk2/core/config/UriConfig.kt
@@ -90,4 +90,5 @@ object UriConfig {
   const val CODE_CHALLENGE_METHOD_VAL = "S256"
   const val PROMPT_PARAM = "prompt"
   const val NONCE_PARAM = "nonce"
+  const val STATE_PARAM = "state"
 }


### PR DESCRIPTION
## Summary
- SDK auto-generates a cryptographically secure `state` parameter on
  every auth request (SecureRandom, 32 bytes, base64url-encoded)
- `state` is always appended to the SSO query params
- `handleAuthCode` validates the returned state; on mismatch calls
  `ssoLink.handleAuthError(INVALID_STATE)` instead of completing normally
- Adds `SsoLink.handleAuthError()` to propagate errors through the
  coroutine-deferred flow
- `@VisibleForTesting generatedState` field for unit-test assertions

This is step 1/3 of iOS parity (PR #337 in uber-ios-sdk).

## Test Plan


## Issues


## Stack
1. @ #272
1. #273
1. #274
