### PR TITLE
[auth] Auto-generate nonce when caller does not provide one

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -55,7 +55,8 @@ class AuthProvider(
   private val ssoLink = SsoLinkFactory.generateSsoLink(activity, authContext)
 
   @VisibleForTesting internal val generatedState: String = generateSecureToken()
-  @VisibleForTesting internal val effectiveNonce: String = authContext.nonce ?: generateSecureToken()
+  @VisibleForTesting
+  internal val effectiveNonce: String = authContext.nonce ?: generateSecureToken()
 
   override suspend fun authenticate(): AuthResult {
     val ssoConfig = withContext(Dispatchers.IO) { SsoConfigProvider.getSsoConfig(activity) }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -55,6 +55,7 @@ class AuthProvider(
   private val ssoLink = SsoLinkFactory.generateSsoLink(activity, authContext)
 
   @VisibleForTesting internal val generatedState: String = generateSecureToken()
+  @VisibleForTesting internal val effectiveNonce: String = authContext.nonce ?: generateSecureToken()
 
   override suspend fun authenticate(): AuthResult {
     val ssoConfig = withContext(Dispatchers.IO) { SsoConfigProvider.getSsoConfig(activity) }
@@ -122,7 +123,7 @@ class AuthProvider(
   private fun getQueryParams(parResponse: PARResponse) = buildMap {
     parResponse.requestUri.takeIf { it.isNotEmpty() }?.let { put(REQUEST_URI, it) }
     authContext.prompt?.let { put(UriConfig.PROMPT_PARAM, it.value) }
-    authContext.nonce?.let { put(UriConfig.NONCE_PARAM, it) }
+    put(UriConfig.NONCE_PARAM, effectiveNonce)
     put(UriConfig.STATE_PARAM, generatedState)
     if (authContext.authType is AuthType.PKCE) {
       val codeChallenge = codeVerifierGenerator.generateCodeChallenge(verifier)

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -432,4 +432,30 @@ class AuthProviderTest : RobolectricTestBase() {
     assert(authProvider.effectiveNonce == authProvider.effectiveNonce)
     assert(authProvider.effectiveNonce.isNotEmpty())
   }
+
+  @Test
+  fun `PKCE flow includes auto-generated nonce in SSO params`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("code")
+    whenever(codeVerifierGenerator.generateCodeVerifier()).thenReturn("verifier")
+    whenever(codeVerifierGenerator.generateCodeChallenge("verifier")).thenReturn("challenge")
+    whenever(authService.token(any(), any(), any(), any(), any()))
+      .thenReturn(Response.success(UberToken(accessToken = "accessToken")))
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.PKCE(), null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val captor = argumentCaptor<Map<String, String>>()
+    authProvider.authenticate()
+    verify(ssoLink).execute(captor.capture())
+    assert(captor.lastValue.containsKey(UriConfig.NONCE_PARAM))
+    assert(captor.lastValue[UriConfig.NONCE_PARAM] == authProvider.effectiveNonce)
+  }
+
+  @Test
+  fun `two different AuthProvider instances generate distinct nonces`() {
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
+    val provider1 = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val provider2 = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    assert(provider1.effectiveNonce != provider2.effectiveNonce)
+  }
 }

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -125,8 +125,8 @@ class AuthProviderTest : RobolectricTestBase() {
     assert(argumentCaptor.firstValue[CODE_CHALLENGE_PARAM] == "challenge")
     assert(argumentCaptor.firstValue[CODE_CHALLENGE_METHOD] == CODE_CHALLENGE_METHOD_VAL)
     assert(argumentCaptor.firstValue.containsValue(UriConfig.PROMPT_PARAM).not())
-    // request_uri + code_challenge + code_challenge_method + state = 4
-    assert(argumentCaptor.firstValue.size == 4)
+    // request_uri + code_challenge + code_challenge_method + state + nonce = 5
+    assert(argumentCaptor.firstValue.size == 5)
     assert(result is AuthResult.Success)
     assert((result as AuthResult.Success).uberToken.accessToken == "accessToken")
   }
@@ -149,8 +149,8 @@ class AuthProviderTest : RobolectricTestBase() {
     verify(authService, never()).token(any(), any(), any(), any(), any())
     verify(ssoLink).execute(argumentCaptor.capture())
     assert(argumentCaptor.lastValue[REQUEST_URI] == "requestUri")
-    // request_uri + state = 2
-    assert(argumentCaptor.lastValue.size == 2)
+    // request_uri + state + nonce = 3
+    assert(argumentCaptor.lastValue.size == 3)
     assert(result is AuthResult.Success)
     assert((result as AuthResult.Success).uberToken.authCode == "authCode")
   }
@@ -168,9 +168,10 @@ class AuthProviderTest : RobolectricTestBase() {
       val result = authProvider.authenticate()
       verify(authService, never()).token(any(), any(), any(), any(), any())
       verify(ssoLink).execute(argumentCaptor.capture())
-      // state is always included; no request_uri when prefillInfo is null
-      assert(argumentCaptor.lastValue.size == 1)
+      // state + nonce always included; no request_uri when prefillInfo is null
+      assert(argumentCaptor.lastValue.size == 2)
       assert(argumentCaptor.lastValue.containsKey(STATE_PARAM))
+      assert(argumentCaptor.lastValue.containsKey(UriConfig.NONCE_PARAM))
       assert(result is AuthResult.Success)
       assert((result as AuthResult.Success).uberToken.authCode == "authCode")
     }
@@ -229,7 +230,7 @@ class AuthProviderTest : RobolectricTestBase() {
   }
 
   @Test
-  fun `test authenticate when nonce is absent should not include nonce query param`() = runTest {
+  fun `test authenticate when nonce is absent should auto-generate nonce query param`() = runTest {
     whenever(ssoLink.execute(any())).thenReturn("authCode")
     whenever(authService.loginParRequest(any(), any(), any(), any()))
       .thenReturn(Response.success(PARResponse("requestUri", "codeVerifier")))
@@ -239,7 +240,7 @@ class AuthProviderTest : RobolectricTestBase() {
     val argumentCaptor = argumentCaptor<Map<String, String>>()
     authProvider.authenticate()
     verify(ssoLink).execute(argumentCaptor.capture())
-    assert(argumentCaptor.lastValue.containsKey(UriConfig.NONCE_PARAM).not())
+    assert(argumentCaptor.lastValue.containsKey(UriConfig.NONCE_PARAM))
   }
 
   @Test
@@ -387,5 +388,48 @@ class AuthProviderTest : RobolectricTestBase() {
     authProvider.handleAuthCode("authCode", null)
     verify(ssoLink).handleAuthCode("authCode")
     verify(ssoLink, never()).handleAuthError(any())
+  }
+
+  // ---- Nonce auto-generation tests ----
+
+  @Test
+  fun `auto-generated nonce is non-empty and forwarded to SSO params`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("authCode")
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val captor = argumentCaptor<Map<String, String>>()
+    authProvider.authenticate()
+    verify(ssoLink).execute(captor.capture())
+    val nonce = captor.lastValue[UriConfig.NONCE_PARAM]
+    assert(!nonce.isNullOrEmpty())
+    assert(nonce == authProvider.effectiveNonce)
+  }
+
+  @Test
+  fun `caller-provided nonce is used verbatim and not replaced`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("authCode")
+    val authContext =
+      AuthContext(
+        AuthDestination.CrossAppSso(listOf(CrossApp.Rider)),
+        AuthType.AuthCode,
+        null,
+        nonce = "caller-nonce-xyz",
+      )
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val captor = argumentCaptor<Map<String, String>>()
+    authProvider.authenticate()
+    verify(ssoLink).execute(captor.capture())
+    assert(captor.lastValue[UriConfig.NONCE_PARAM] == "caller-nonce-xyz")
+    assert(authProvider.effectiveNonce == "caller-nonce-xyz")
+  }
+
+  @Test
+  fun `effectiveNonce is stable — same value on every access`() {
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    assert(authProvider.effectiveNonce == authProvider.effectiveNonce)
+    assert(authProvider.effectiveNonce.isNotEmpty())
   }
 }


### PR DESCRIPTION
## Summary
- SDK now auto-generates a cryptographically secure `nonce` parameter
  (SecureRandom, 32 bytes, base64url) when `AuthContext.nonce` is null
- `effectiveNonce = authContext.nonce ?: generateSecureToken()` ensures
  nonce is always present in SSO query params for replay attack prevention
- Callers that supply their own nonce (for backend binding) are unaffected
- `@VisibleForTesting effectiveNonce` field exposed for assertions

This is step 2/3 of iOS parity (PR #337 in uber-ios-sdk).

## Test Plan


## Issues


## Stack
1. #272
1. @ #273
1. #274
