### PR TITLE
[auth] Add id_token field to UberToken and validate nonce claim

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
@@ -49,5 +49,8 @@ sealed class AuthException(override val message: String) : RuntimeException(mess
     internal const val UNKNOWN = "Unknown error occurred"
 
     internal const val INVALID_STATE = "State parameter mismatch possible CSRF attack"
+
+    internal const val NONCE_MISMATCH =
+      "Nonce claim in id_token does not match possible replay attack"
   }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
@@ -52,5 +52,8 @@ sealed class AuthException(override val message: String) : RuntimeException(mess
 
     internal const val NONCE_MISMATCH =
       "Nonce claim in id_token does not match possible replay attack"
+
+    internal const val ID_TOKEN_PARSE_FAILED =
+      "Failed to parse id_token payload for nonce validation"
   }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
@@ -48,6 +48,6 @@ sealed class AuthException(override val message: String) : RuntimeException(mess
 
     internal const val UNKNOWN = "Unknown error occurred"
 
-    internal const val INVALID_STATE = "State parameter mismatch - possible CSRF attack"
+    internal const val INVALID_STATE = "State parameter mismatch possible CSRF attack"
   }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/exception/AuthException.kt
@@ -48,6 +48,6 @@ sealed class AuthException(override val message: String) : RuntimeException(mess
 
     internal const val UNKNOWN = "Unknown error occurred"
 
-    internal const val INVALID_STATE = "State parameter mismatch — possible CSRF attack"
+    internal const val INVALID_STATE = "State parameter mismatch - possible CSRF attack"
   }
 }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -132,7 +132,7 @@ class AuthProvider(
   }
 
   override fun handleAuthCode(authCode: String, state: String?) {
-    if (state != null && state != generatedState) {
+    if (state != generatedState) {
       ssoLink.handleAuthError(AuthException.ClientError(AuthException.INVALID_STATE))
       return
     }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -55,7 +55,8 @@ class AuthProvider(
   private val ssoLink = SsoLinkFactory.generateSsoLink(activity, authContext)
 
   @VisibleForTesting internal val generatedState: String = generateSecureToken()
-  @VisibleForTesting internal val effectiveNonce: String = authContext.nonce ?: generateSecureToken()
+  @VisibleForTesting
+  internal val effectiveNonce: String = authContext.nonce ?: generateSecureToken()
 
   override suspend fun authenticate(): AuthResult {
     val ssoConfig = withContext(Dispatchers.IO) { SsoConfigProvider.getSsoConfig(activity) }

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -44,6 +44,7 @@ import com.uber.sdk2.core.config.UriConfig.REQUEST_URI
 import java.security.SecureRandom
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.json.JSONObject
 
 class AuthProvider(
   private val activity: AppCompatActivity,
@@ -87,13 +88,32 @@ class AuthProvider(
         authCode,
       )
 
-    return if (tokenResponse.isSuccessful) {
-      tokenResponse.body()?.let { AuthResult.Success(it) }
-        ?: AuthResult.Error(AuthException.ClientError("Token request failed with empty response"))
-    } else {
-      AuthResult.Error(
+    if (!tokenResponse.isSuccessful) {
+      return AuthResult.Error(
         AuthException.ClientError("Token request failed with code: ${tokenResponse.code()}")
       )
+    }
+    val token =
+      tokenResponse.body()
+        ?: return AuthResult.Error(
+          AuthException.ClientError("Token request failed with empty response")
+        )
+    token.idToken?.let { idToken ->
+      val claimNonce = extractNonceFromIdToken(idToken)
+      if (claimNonce != effectiveNonce) {
+        return AuthResult.Error(AuthException.ClientError(AuthException.NONCE_MISMATCH))
+      }
+    }
+    return AuthResult.Success(token)
+  }
+
+  private fun extractNonceFromIdToken(idToken: String): String? {
+    return try {
+      val payload = idToken.split(".").getOrNull(1) ?: return null
+      val decoded = android.util.Base64.decode(payload, android.util.Base64.URL_SAFE)
+      JSONObject(String(decoded)).optString("nonce").takeIf { it.isNotEmpty() }
+    } catch (_: Exception) {
+      null
     }
   }
 

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -55,6 +55,7 @@ class AuthProvider(
   private val ssoLink = SsoLinkFactory.generateSsoLink(activity, authContext)
 
   @VisibleForTesting internal val generatedState: String = generateSecureToken()
+  @VisibleForTesting internal val effectiveNonce: String = authContext.nonce ?: generateSecureToken()
 
   override suspend fun authenticate(): AuthResult {
     val ssoConfig = withContext(Dispatchers.IO) { SsoConfigProvider.getSsoConfig(activity) }
@@ -122,7 +123,7 @@ class AuthProvider(
   private fun getQueryParams(parResponse: PARResponse) = buildMap {
     parResponse.requestUri.takeIf { it.isNotEmpty() }?.let { put(REQUEST_URI, it) }
     authContext.prompt?.let { put(UriConfig.PROMPT_PARAM, it.value) }
-    authContext.nonce?.let { put(UriConfig.NONCE_PARAM, it) }
+    put(UriConfig.NONCE_PARAM, effectiveNonce)
     put(UriConfig.STATE_PARAM, generatedState)
     if (authContext.authType is AuthType.PKCE) {
       val codeChallenge = codeVerifierGenerator.generateCodeChallenge(verifier)

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/AuthProvider.kt
@@ -100,6 +100,9 @@ class AuthProvider(
         )
     token.idToken?.let { idToken ->
       val claimNonce = extractNonceFromIdToken(idToken)
+      if (claimNonce == null) {
+        return AuthResult.Error(AuthException.ClientError(AuthException.ID_TOKEN_PARSE_FAILED))
+      }
       if (claimNonce != effectiveNonce) {
         return AuthResult.Error(AuthException.ClientError(AuthException.NONCE_MISMATCH))
       }
@@ -110,7 +113,7 @@ class AuthProvider(
   private fun extractNonceFromIdToken(idToken: String): String? {
     return try {
       val payload = idToken.split(".").getOrNull(1) ?: return null
-      val decoded = android.util.Base64.decode(payload, android.util.Base64.URL_SAFE)
+      val decoded = Base64.decode(payload, Base64.URL_SAFE)
       JSONObject(String(decoded)).optString("nonce").takeIf { it.isNotEmpty() }
     } catch (_: Exception) {
       null

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/response/UberToken.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/response/UberToken.kt
@@ -33,4 +33,5 @@ data class UberToken(
   @Json(name = "refresh_token") val refreshToken: String? = null,
   @Json(name = "expires_in") val expiresIn: Long? = null,
   @Json(name = "scope") val scope: String? = null,
+  @Json(name = "id_token") val idToken: String? = null,
 ) : Parcelable

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -432,4 +432,30 @@ class AuthProviderTest : RobolectricTestBase() {
     assert(authProvider.effectiveNonce == authProvider.effectiveNonce)
     assert(authProvider.effectiveNonce.isNotEmpty())
   }
+
+  @Test
+  fun `PKCE flow includes auto-generated nonce in SSO params`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("code")
+    whenever(codeVerifierGenerator.generateCodeVerifier()).thenReturn("verifier")
+    whenever(codeVerifierGenerator.generateCodeChallenge("verifier")).thenReturn("challenge")
+    whenever(authService.token(any(), any(), any(), any(), any()))
+      .thenReturn(Response.success(UberToken(accessToken = "accessToken")))
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.PKCE(), null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val captor = argumentCaptor<Map<String, String>>()
+    authProvider.authenticate()
+    verify(ssoLink).execute(captor.capture())
+    assert(captor.lastValue.containsKey(UriConfig.NONCE_PARAM))
+    assert(captor.lastValue[UriConfig.NONCE_PARAM] == authProvider.effectiveNonce)
+  }
+
+  @Test
+  fun `two different AuthProvider instances generate distinct nonces`() {
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
+    val provider1 = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val provider2 = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    assert(provider1.effectiveNonce != provider2.effectiveNonce)
+  }
 }

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -125,8 +125,8 @@ class AuthProviderTest : RobolectricTestBase() {
     assert(argumentCaptor.firstValue[CODE_CHALLENGE_PARAM] == "challenge")
     assert(argumentCaptor.firstValue[CODE_CHALLENGE_METHOD] == CODE_CHALLENGE_METHOD_VAL)
     assert(argumentCaptor.firstValue.containsValue(UriConfig.PROMPT_PARAM).not())
-    // request_uri + code_challenge + code_challenge_method + state = 4
-    assert(argumentCaptor.firstValue.size == 4)
+    // request_uri + code_challenge + code_challenge_method + state + nonce = 5
+    assert(argumentCaptor.firstValue.size == 5)
     assert(result is AuthResult.Success)
     assert((result as AuthResult.Success).uberToken.accessToken == "accessToken")
   }
@@ -149,8 +149,8 @@ class AuthProviderTest : RobolectricTestBase() {
     verify(authService, never()).token(any(), any(), any(), any(), any())
     verify(ssoLink).execute(argumentCaptor.capture())
     assert(argumentCaptor.lastValue[REQUEST_URI] == "requestUri")
-    // request_uri + state = 2
-    assert(argumentCaptor.lastValue.size == 2)
+    // request_uri + state + nonce = 3
+    assert(argumentCaptor.lastValue.size == 3)
     assert(result is AuthResult.Success)
     assert((result as AuthResult.Success).uberToken.authCode == "authCode")
   }
@@ -168,9 +168,10 @@ class AuthProviderTest : RobolectricTestBase() {
       val result = authProvider.authenticate()
       verify(authService, never()).token(any(), any(), any(), any(), any())
       verify(ssoLink).execute(argumentCaptor.capture())
-      // state is always included; no request_uri when prefillInfo is null
-      assert(argumentCaptor.lastValue.size == 1)
+      // state + nonce always included; no request_uri when prefillInfo is null
+      assert(argumentCaptor.lastValue.size == 2)
       assert(argumentCaptor.lastValue.containsKey(STATE_PARAM))
+      assert(argumentCaptor.lastValue.containsKey(UriConfig.NONCE_PARAM))
       assert(result is AuthResult.Success)
       assert((result as AuthResult.Success).uberToken.authCode == "authCode")
     }
@@ -229,7 +230,7 @@ class AuthProviderTest : RobolectricTestBase() {
   }
 
   @Test
-  fun `test authenticate when nonce is absent should not include nonce query param`() = runTest {
+  fun `test authenticate when nonce is absent should auto-generate nonce query param`() = runTest {
     whenever(ssoLink.execute(any())).thenReturn("authCode")
     whenever(authService.loginParRequest(any(), any(), any(), any()))
       .thenReturn(Response.success(PARResponse("requestUri", "codeVerifier")))
@@ -239,7 +240,7 @@ class AuthProviderTest : RobolectricTestBase() {
     val argumentCaptor = argumentCaptor<Map<String, String>>()
     authProvider.authenticate()
     verify(ssoLink).execute(argumentCaptor.capture())
-    assert(argumentCaptor.lastValue.containsKey(UriConfig.NONCE_PARAM).not())
+    assert(argumentCaptor.lastValue.containsKey(UriConfig.NONCE_PARAM))
   }
 
   @Test
@@ -387,5 +388,48 @@ class AuthProviderTest : RobolectricTestBase() {
     authProvider.handleAuthCode("authCode", null)
     verify(ssoLink, never()).handleAuthCode(any())
     verify(ssoLink).handleAuthError(argThat { message == AuthException.INVALID_STATE })
+  }
+
+  // ---- Nonce auto-generation tests ----
+
+  @Test
+  fun `auto-generated nonce is non-empty and forwarded to SSO params`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("authCode")
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val captor = argumentCaptor<Map<String, String>>()
+    authProvider.authenticate()
+    verify(ssoLink).execute(captor.capture())
+    val nonce = captor.lastValue[UriConfig.NONCE_PARAM]
+    assert(!nonce.isNullOrEmpty())
+    assert(nonce == authProvider.effectiveNonce)
+  }
+
+  @Test
+  fun `caller-provided nonce is used verbatim and not replaced`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("authCode")
+    val authContext =
+      AuthContext(
+        AuthDestination.CrossAppSso(listOf(CrossApp.Rider)),
+        AuthType.AuthCode,
+        null,
+        nonce = "caller-nonce-xyz",
+      )
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val captor = argumentCaptor<Map<String, String>>()
+    authProvider.authenticate()
+    verify(ssoLink).execute(captor.capture())
+    assert(captor.lastValue[UriConfig.NONCE_PARAM] == "caller-nonce-xyz")
+    assert(authProvider.effectiveNonce == "caller-nonce-xyz")
+  }
+
+  @Test
+  fun `effectiveNonce is stable — same value on every access`() {
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    assert(authProvider.effectiveNonce == authProvider.effectiveNonce)
+    assert(authProvider.effectiveNonce.isNotEmpty())
   }
 }

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -462,14 +462,20 @@ class AuthProviderTest : RobolectricTestBase() {
   // ---- id_token nonce validation tests ----
 
   private fun buildFakeIdToken(nonce: String): String {
-    val header = android.util.Base64.encodeToString(
-      """{"alg":"RS256"}""".toByteArray(),
-      android.util.Base64.URL_SAFE or android.util.Base64.NO_WRAP or android.util.Base64.NO_PADDING,
-    )
-    val payload = android.util.Base64.encodeToString(
-      """{"sub":"uid123","nonce":"$nonce"}""".toByteArray(),
-      android.util.Base64.URL_SAFE or android.util.Base64.NO_WRAP or android.util.Base64.NO_PADDING,
-    )
+    val header =
+      android.util.Base64.encodeToString(
+        """{"alg":"RS256"}""".toByteArray(),
+        android.util.Base64.URL_SAFE or
+          android.util.Base64.NO_WRAP or
+          android.util.Base64.NO_PADDING,
+      )
+    val payload =
+      android.util.Base64.encodeToString(
+        """{"sub":"uid123","nonce":"$nonce"}""".toByteArray(),
+        android.util.Base64.URL_SAFE or
+          android.util.Base64.NO_WRAP or
+          android.util.Base64.NO_PADDING,
+      )
     return "$header.$payload.fakesig"
   }
 

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -458,4 +458,65 @@ class AuthProviderTest : RobolectricTestBase() {
     val provider2 = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
     assert(provider1.effectiveNonce != provider2.effectiveNonce)
   }
+
+  // ---- id_token nonce validation tests ----
+
+  private fun buildFakeIdToken(nonce: String): String {
+    val header = android.util.Base64.encodeToString(
+      """{"alg":"RS256"}""".toByteArray(),
+      android.util.Base64.URL_SAFE or android.util.Base64.NO_WRAP or android.util.Base64.NO_PADDING,
+    )
+    val payload = android.util.Base64.encodeToString(
+      """{"sub":"uid123","nonce":"$nonce"}""".toByteArray(),
+      android.util.Base64.URL_SAFE or android.util.Base64.NO_WRAP or android.util.Base64.NO_PADDING,
+    )
+    return "$header.$payload.fakesig"
+  }
+
+  @Test
+  fun `PKCE with matching id_token nonce succeeds`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("code")
+    whenever(codeVerifierGenerator.generateCodeVerifier()).thenReturn("verifier")
+    whenever(codeVerifierGenerator.generateCodeChallenge("verifier")).thenReturn("challenge")
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.PKCE(), null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val idToken = buildFakeIdToken(authProvider.effectiveNonce)
+    whenever(authService.token(any(), any(), any(), any(), any()))
+      .thenReturn(Response.success(UberToken(accessToken = "accessToken", idToken = idToken)))
+    val result = authProvider.authenticate()
+    assert(result is AuthResult.Success)
+    assert((result as AuthResult.Success).uberToken.idToken == idToken)
+  }
+
+  @Test
+  fun `PKCE with mismatched id_token nonce returns NONCE_MISMATCH error`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("code")
+    whenever(codeVerifierGenerator.generateCodeVerifier()).thenReturn("verifier")
+    whenever(codeVerifierGenerator.generateCodeChallenge("verifier")).thenReturn("challenge")
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.PKCE(), null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val idToken = buildFakeIdToken("wrong-nonce")
+    whenever(authService.token(any(), any(), any(), any(), any()))
+      .thenReturn(Response.success(UberToken(accessToken = "accessToken", idToken = idToken)))
+    val result = authProvider.authenticate()
+    assert(result is AuthResult.Error)
+    assert((result as AuthResult.Error).authException.message == AuthException.NONCE_MISMATCH)
+  }
+
+  @Test
+  fun `PKCE without id_token skips nonce validation and succeeds`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("code")
+    whenever(codeVerifierGenerator.generateCodeVerifier()).thenReturn("verifier")
+    whenever(codeVerifierGenerator.generateCodeChallenge("verifier")).thenReturn("challenge")
+    whenever(authService.token(any(), any(), any(), any(), any()))
+      .thenReturn(Response.success(UberToken(accessToken = "accessToken", idToken = null)))
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.PKCE(), null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    val result = authProvider.authenticate()
+    assert(result is AuthResult.Success)
+    assert((result as AuthResult.Success).uberToken.accessToken == "accessToken")
+  }
 }

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -380,12 +380,12 @@ class AuthProviderTest : RobolectricTestBase() {
   }
 
   @Test
-  fun `handleAuthCode with null state skips state validation`() {
+  fun `handleAuthCode with null state triggers state mismatch error`() {
     val authContext =
       AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.AuthCode, null)
     val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
     authProvider.handleAuthCode("authCode", null)
-    verify(ssoLink).handleAuthCode("authCode")
-    verify(ssoLink, never()).handleAuthError(any())
+    verify(ssoLink, never()).handleAuthCode(any())
+    verify(ssoLink).handleAuthError(argThat { message == AuthException.INVALID_STATE })
   }
 }

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/AuthProviderTest.kt
@@ -525,4 +525,23 @@ class AuthProviderTest : RobolectricTestBase() {
     assert(result is AuthResult.Success)
     assert((result as AuthResult.Success).uberToken.accessToken == "accessToken")
   }
+
+  @Test
+  fun `PKCE with malformed id_token returns ID_TOKEN_PARSE_FAILED error`() = runTest {
+    whenever(ssoLink.execute(any())).thenReturn("code")
+    whenever(codeVerifierGenerator.generateCodeVerifier()).thenReturn("verifier")
+    whenever(codeVerifierGenerator.generateCodeChallenge("verifier")).thenReturn("challenge")
+    val authContext =
+      AuthContext(AuthDestination.CrossAppSso(listOf(CrossApp.Rider)), AuthType.PKCE(), null)
+    val authProvider = AuthProvider(activity, authContext, authService, codeVerifierGenerator)
+    whenever(authService.token(any(), any(), any(), any(), any()))
+      .thenReturn(
+        Response.success(UberToken(accessToken = "accessToken", idToken = "not-a-valid-jwt"))
+      )
+    val result = authProvider.authenticate()
+    assert(result is AuthResult.Error)
+    assert(
+      (result as AuthResult.Error).authException.message == AuthException.ID_TOKEN_PARSE_FAILED
+    )
+  }
 }


### PR DESCRIPTION
## Summary
- `UberToken` gains `@Json(name = "id_token") val idToken: String?` for
  OIDC id_token deserialization
- `AuthException.NONCE_MISMATCH` constant added for replay-attack detection
- `performPkce` validates the `nonce` claim in `id_token` against
  `effectiveNonce`; returns `NONCE_MISMATCH` error on mismatch
- `extractNonceFromIdToken` decodes the JWT payload (base64url) and
  extracts the `nonce` claim via `org.json.JSONObject` — no extra libs
- Validation is skipped when server returns no `id_token` (backward compat)

This is step 3/3 of iOS parity (PR #337 in uber-ios-sdk).

## Test Plan


## Issues


## Stack
1. #272
1. #273
1. @ #274
