### PR TITLE
[auth] Add NonceUtil for JWT nonce extraction and id_token field to UberToken

### DIFF
--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/utils/NonceUtil.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/utils/NonceUtil.kt
@@ -19,19 +19,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.sdk2.auth.response
+package com.uber.sdk2.auth.internal.utils
 
-import android.os.Parcelable
-import com.squareup.moshi.Json
-import kotlinx.parcelize.Parcelize
+import android.util.Base64
+import org.json.JSONObject
 
-/** Holds the OAuth token that is returned after a successful authentication request. */
-@Parcelize
-data class UberToken(
-  val authCode: String? = null,
-  @Json(name = "access_token") val accessToken: String? = null,
-  @Json(name = "refresh_token") val refreshToken: String? = null,
-  @Json(name = "expires_in") val expiresIn: Long? = null,
-  @Json(name = "scope") val scope: String? = null,
-  @Json(name = "id_token") val idToken: String? = null,
-) : Parcelable
+object NonceUtil {
+
+  /**
+   * Extracts the `nonce` claim from a JWT id_token by decoding the payload segment (without
+   * verifying the signature). Returns null if the token is malformed or contains no nonce claim.
+   */
+  fun extractNonceFromIdToken(idToken: String): String? {
+    val parts = idToken.split(".")
+    if (parts.size != 3) return null
+    return try {
+      val payload = Base64.decode(parts[1], Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+      val json = JSONObject(String(payload, Charsets.UTF_8))
+      json.optString("nonce", null)
+    } catch (_: Exception) {
+      null
+    }
+  }
+}

--- a/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/utils/NonceUtil.kt
+++ b/authentication/src/main/kotlin/com/uber/sdk2/auth/internal/utils/NonceUtil.kt
@@ -30,6 +30,7 @@ object NonceUtil {
    * Extracts the `nonce` claim from a JWT id_token by decoding the payload segment (without
    * verifying the signature). Returns null if the token is malformed or contains no nonce claim.
    */
+  @JvmStatic
   fun extractNonceFromIdToken(idToken: String): String? {
     val parts = idToken.split(".")
     if (parts.size != 3) return null

--- a/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/utils/NonceUtilTest.kt
+++ b/authentication/src/test/kotlin/com/uber/sdk2/auth/internal/utils/NonceUtilTest.kt
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2024 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.sdk2.auth.internal.utils
+
+import com.uber.sdk2.auth.RobolectricTestBase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NonceUtilTest : RobolectricTestBase() {
+
+  private fun buildJwt(payloadJson: String): String {
+    val header =
+      android.util.Base64.encodeToString(
+        """{"alg":"RS256","typ":"JWT"}""".toByteArray(),
+        android.util.Base64.URL_SAFE or
+          android.util.Base64.NO_WRAP or
+          android.util.Base64.NO_PADDING,
+      )
+    val payload =
+      android.util.Base64.encodeToString(
+        payloadJson.toByteArray(),
+        android.util.Base64.URL_SAFE or
+          android.util.Base64.NO_WRAP or
+          android.util.Base64.NO_PADDING,
+      )
+    return "$header.$payload.fake-signature"
+  }
+
+  @Test
+  fun `extractNonceFromIdToken returns nonce when present`() {
+    val jwt = buildJwt("""{"sub":"user123","nonce":"my-nonce-value"}""")
+    assertEquals("my-nonce-value", NonceUtil.extractNonceFromIdToken(jwt))
+  }
+
+  @Test
+  fun `extractNonceFromIdToken returns null when nonce is absent`() {
+    val jwt = buildJwt("""{"sub":"user123"}""")
+    assertNull(NonceUtil.extractNonceFromIdToken(jwt))
+  }
+
+  @Test
+  fun `extractNonceFromIdToken returns null for malformed JWT`() {
+    assertNull(NonceUtil.extractNonceFromIdToken("not-a-jwt"))
+  }
+
+  @Test
+  fun `extractNonceFromIdToken returns null for two-segment token`() {
+    assertNull(NonceUtil.extractNonceFromIdToken("header.payload"))
+  }
+
+  @Test
+  fun `extractNonceFromIdToken returns null for invalid base64 payload`() {
+    assertNull(NonceUtil.extractNonceFromIdToken("header.!!!invalid!!!.sig"))
+  }
+}


### PR DESCRIPTION
Summary:
- Intent:
  - Provide a reusable utility for extracting the \`nonce\` claim from a JWT \`id_token\` payload without signature verification, matching the approach in the iOS SDK.
  - Add the \`id_token\` field to \`UberToken\` so PKCE flows can receive and inspect it.

- Changes:
  - New \`NonceUtil.extractNonceFromIdToken()\` — decodes the base64url payload segment and returns the \`nonce\` claim; returns null on malformed input.
  - Added \`idToken\` field to \`UberToken\`.
  - \`NonceUtilTest\` covers nonce-present, nonce-absent, malformed JWT, two-segment token, and invalid base64 cases.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>